### PR TITLE
Add definitions for sql tables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ devel:
 # (you must have a compile error in the code you want to dump)
 dump-th:
 	stack build --ghc-options="-ddump-splices"
+	@echo
+	@echo "Splice files:"
+	@echo
+	@find "$$(stack path --dist-dir)" -name "*.dump-splices"
 
 ghci:
 	stack ghci

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -33,17 +33,20 @@ library
                      , Kucipong.Monad.Db.Trans
                      , Kucipong.Orphans
                      , Kucipong.Prelude
+                     , Kucipong.Util
   build-depends:       base >= 4.7 && < 5
                      , aeson
                      , classy-prelude
                      , email-validate
                      , envelope
+                     , http-api-data
                      , http-client
                      , http-conduit
                      , lens
                      , monad-control
                      , monad-logger
                      , mtl
+                     , path-pieces
                      , persistent
                      , persistent-postgresql
                      , persistent-template

--- a/src/Kucipong/Db/Models.hs
+++ b/src/Kucipong/Db/Models.hs
@@ -7,20 +7,19 @@ module Kucipong.Db.Models
     , module Kucipong.Db.Models.Base
     , EntityField(..)
     , Key(..)
-    , Unique(..)
+    , Unique
     ) where
 
 import Kucipong.Prelude
 
 import Database.Persist
-    ( EntityField(..), Key(..), Unique(..) )
+    ( EntityField(..), Key(..), Unique )
 import Database.Persist.TH (
     share, mkPersist, sqlSettings, mkMigrate, mpsGenerateLenses,
     )
 
 import Kucipong.Db.Models.Base
-    ( CreatedTime, DeletedTime, Password(..), PasswordHash, UpdatedTime
-    , passwordHash
+    ( CouponType, CreatedTime, DeletedTime, Image, Percent, Price, UpdatedTime
     )
 import Kucipong.Db.Models.EntityDefs ( kucipongEntityDefs )
 

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -1,33 +1,45 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Kucipong.Db.Models.Base where
 
 import Kucipong.Prelude
 
-import Control.Lens.TH ( makeLenses )
 import Data.Aeson ( FromJSON, ToJSON )
-import Database.Persist ( PersistField )
-import Database.Persist.Sql ( PersistFieldSql )
+import Database.Persist ( PersistField(..), PersistValue )
+import Database.Persist.Sql ( PersistFieldSql(..), SqlType )
+import GHC.Natural ( Natural )
 
---------------
--- Password --
---------------
+------------
+-- Coupon --
+------------
 
-newtype Password = Password { unPassword :: Text }
+data CouponType
+    = CouponTypeDiscount
+    | CouponTypePresent
+    | CouponTypeSet
     deriving
-        ( Data, Eq, FromJSON, Generic, IsString, Ord, Show, ToJSON, Typeable
-        )
+        ( Data, Eq, Generic, Show, Typeable )
 
--------------------
--- Password Hash --
--------------------
+couponTypeToText :: CouponType -> Text
+couponTypeToText CouponTypeDiscount = "discount"
+couponTypeToText CouponTypePresent = "present"
+couponTypeToText CouponTypeSet = "set"
 
-newtype PasswordHash = PasswordHash { _passwordHash :: ByteString }
-    deriving
-        ( Data, Eq, Generic, IsString, Ord, PersistField, PersistFieldSql, Show
-        , Typeable
-        )
-makeLenses ''PasswordHash
+couponTypeFromText :: Text -> Either Text CouponType
+couponTypeFromText "discount" = pure CouponTypeDiscount
+couponTypeFromText "present" = pure CouponTypePresent
+couponTypeFromText "set" = pure CouponTypeSet
+couponTypeFromText text = Left $ "Tried to convert \"" <> text
+    <> "\"to coupon type, but failed."
+
+instance PersistField CouponType where
+    toPersistValue :: CouponType -> PersistValue
+    toPersistValue = toPersistValue . couponTypeToText
+
+    fromPersistValue :: PersistValue -> Either Text CouponType
+    fromPersistValue = couponTypeFromText <=< fromPersistValue
+
+instance PersistFieldSql CouponType where
+    sqlType :: Proxy CouponType -> SqlType
+    sqlType _ = sqlType (Proxy :: Proxy Text)
 
 ------------------------------------
 -- Created, modified, delete time --
@@ -47,3 +59,28 @@ newtype DeletedTime = DeletedTime { unDeletedTime :: UTCTime }
     deriving
         ( Data, Eq, FromJSON, Generic, Ord, PersistField, PersistFieldSql, Show
         , ToJSON, Typeable )
+
+-----------
+-- Image --
+-----------
+
+newtype Image = Image { unImage :: Text }
+    deriving
+        ( Data, Eq, FromJSON, Generic, Ord, PersistField, PersistFieldSql, Show
+        , ToJSON, Typeable )
+
+-------------
+-- Percent --
+-------------
+
+newtype Percent = Percent { unPercent :: Natural }
+    deriving
+        ( Data, Eq, Generic, PersistField, PersistFieldSql, Show, Typeable )
+
+-----------
+-- Price --
+-----------
+
+newtype Price = Price { unPrice :: Int64 }
+    deriving
+        ( Data, Eq, Generic, PersistField, PersistFieldSql, Show, Typeable )

--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -62,23 +62,14 @@ kucipongEntityDefs = [persistLowerCase|
         title                   Text
         validUntil              UTCTime
         couponType              CouponType
-
-    CouponDiscount
-        couponId                CouponId
-        percent                 Percent
-        minimumPrice            Price
-        requirements            Text
-
-    CouponPresent
-        couponId                CouponId
-        description             Text
-        price                   Price Maybe
-        minimumPrice            Price
-        requirements            Text
-
-    CouponSet
-        couponId                CouponId
-        description             Text
-        price                   Price Maybe
-        requirements            Text
+        discountPercent         Percent Maybe
+        discountMinimumPrice    Price Maybe
+        discountRequirements    Text Maybe
+        presentDescription      Text Maybe
+        presentPrice            Price Maybe
+        presentMinimumPrice     Price Maybe
+        presentRequirements     Text Maybe
+        setDescription          Text Maybe
+        setPrice                Price Maybe
+        setRequirements         Text Maybe
     |]

--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -8,31 +8,77 @@ import Database.Persist ( EntityDef )
 import Database.Persist.TH ( persistLowerCase )
 
 import Kucipong.Db.Models.Base
-    ( CreatedTime, DeletedTime, PasswordHash, UpdatedTime )
+    ( CouponType, CreatedTime, DeletedTime, Image, Percent, Price, UpdatedTime )
 
 kucipongEntityDefs :: [EntityDef]
 kucipongEntityDefs = [persistLowerCase|
-    Session
-        validUntil     UTCTime
-        userId         UserId
+    Admin
+        email                   EmailAddress
+        created                 CreatedTime
+        updated                 UpdatedTime
+        deleted                 DeletedTime Maybe
+        name                    Text
 
-        deriving       Show
-        deriving       Typeable
+        Primary email
 
-    -- Removed json directive from here because we don't want to send the
-    -- password hash when turning a user to JSON.
-    User
-        created        CreatedTime
-        updated        UpdatedTime
-        deleted        DeletedTime Maybe
-        email          EmailAddress
-        passwordHash   PasswordHash
+        deriving Eq
+        deriving Show
+        deriving Typeable
 
-        UniqueUserEmail    email
+    CompanyEmail
+        email                   EmailAddress
+        created                 CreatedTime
+        updated                 UpdatedTime
+        deleted                 DeletedTime Maybe
 
-        deriving       Eq
-        deriving       Show
-        deriving       Typeable
+        Primary email
+
+        deriving Eq
+        deriving Show
+        deriving Typeable
+
+    Company
+        created                 CreatedTime
+        updated                 UpdatedTime
+        deleted                 DeletedTime Maybe
+        emailAddr               CompanyEmailId
+        name                    Text
+        businessCategory        Text
+        businessCategoryDetail  Text
+        image                   Image
+        salesPoint              Text
+        address                 Text
+        phoneNumber             Text
+        businessHours           Text
+        regularHoliday          Text
+        url                     Text
+
+        deriving Eq
+        deriving Show
+        deriving Typeable
+
+    Coupon
+        image                   Image
+        title                   Text
+        validUntil              UTCTime
+        couponType              CouponType
+
+    CouponDiscount
+        couponId                CouponId
+        percent                 Percent
+        minimumPrice            Price
+        requirements            Text
+
+    CouponPresent
+        couponId                CouponId
+        description             Text
+        price                   Price Maybe
+        minimumPrice            Price
+        requirements            Text
+
+    CouponSet
+        couponId                CouponId
+        description             Text
+        price                   Price Maybe
+        requirements            Text
     |]
-
-

--- a/src/Kucipong/Monad.hs
+++ b/src/Kucipong/Monad.hs
@@ -22,7 +22,7 @@ type MonadKucipong' m =
     ( MonadKucipongDb m
     )
 
--- | This constraint synonym wraps up all of the type classes used by 'StomeTimeM'.
+-- | This constraint synonym wraps up all of the type classes used by 'KucipongM'.
 type MonadKucipong m =
     ( MonadBaseControl IO m
     , MonadError AppErr m

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -7,28 +7,28 @@ import Kucipong.Prelude
 import Control.Monad.Trans ( MonadTrans )
 import Web.Spock ( ActionCtxT )
 
-import Kucipong.Db ( Key, Password, PasswordHash, User )
+import Kucipong.Db ( Admin, Key )
 
 class Monad m => MonadKucipongDb m where
-    dbInsertNewUser :: EmailAddress -> PasswordHash -> m (Key User)
+    dbInsertNewUser :: EmailAddress -> m (Key Admin)
     default dbInsertNewUser
         :: ( Monad (t n)
            , MonadKucipongDb n
            , MonadTrans t
            , m ~ t n
            )
-        => EmailAddress -> PasswordHash ->  t n (Key User)
-    dbInsertNewUser = (lift .) . dbInsertNewUser
+        => EmailAddress -> t n (Key Admin)
+    dbInsertNewUser = lift . dbInsertNewUser
 
-    dbLoginUser :: EmailAddress -> Password -> m (Maybe (Key User))
+    dbLoginUser :: EmailAddress -> m (Maybe (Key Admin))
     default dbLoginUser
         :: ( Monad (t n)
            , MonadKucipongDb n
            , MonadTrans t
            , m ~ t n
            )
-        => EmailAddress -> Password ->  t n (Maybe (Key User))
-    dbLoginUser = (lift .) . dbLoginUser
+        => EmailAddress -> t n (Maybe (Key Admin))
+    dbLoginUser = lift . dbLoginUser
 
 instance MonadKucipongDb m => MonadKucipongDb (ExceptT e m)
 instance MonadKucipongDb m => MonadKucipongDb (IdentityT m)

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -14,11 +14,7 @@ import Crypto.PasswordStore ( verifyPassword )
 import Database.Persist ( getBy, insert, entityKey, entityVal )
 
 import Kucipong.Config ( Config )
-import Kucipong.Db
-    ( Key, CreatedTime(..), HasDbPool, Password(..), PasswordHash(..)
-    , Session(..), Unique(..), UpdatedTime(..), User(..)
-    , passwordHash, {- runDb, runDbSafeCurrTime, -} userPasswordHash
-    )
+import Kucipong.Db ( Admin, Key )
 import Kucipong.Errors ( AppErr )
 import Kucipong.Monad.Db.Class ( MonadKucipongDb(..) )
 import Kucipong.Monad.Db.Trans ( KucipongDbT(..) )
@@ -29,8 +25,8 @@ instance ( MonadBaseControl IO m
          , MonadReader Config m
          ) => MonadKucipongDb (KucipongDbT m) where
 
-    dbInsertNewUser :: EmailAddress -> PasswordHash -> KucipongDbT m (Key User)
-    dbInsertNewUser email hash = KucipongDbT $ undefined
+    dbInsertNewUser :: EmailAddress -> KucipongDbT m (Key Admin)
+    dbInsertNewUser _ = KucipongDbT $ undefined
         -- lift go
       -- where
         -- go :: m (Key User)
@@ -43,8 +39,8 @@ instance ( MonadBaseControl IO m
         --                     hash
         --         insert user
 
-    dbLoginUser :: EmailAddress -> Password -> KucipongDbT m (Maybe (Key User))
-    dbLoginUser email (Password password) = KucipongDbT $ undefined
+    dbLoginUser :: EmailAddress -> KucipongDbT m (Maybe (Key Admin))
+    dbLoginUser _ = KucipongDbT $ undefined
         -- lift go
       -- where
         -- go :: m (Maybe (Key User))

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -18,7 +18,13 @@ import Data.Aeson.Types ( Parser )
 import Data.Proxy ( Proxy )
 import Database.Persist.Postgresql
     ( PersistField(..), PersistFieldSql(..), PersistValue(..), SqlType(..))
-import Text.Email.Validate ( EmailAddress, toByteString, validate )
+import Text.Email.Validate ( EmailAddress, emailAddress, toByteString, validate )
+import Web.HttpApiData ( FromHttpApiData(..), ToHttpApiData(..) )
+import Web.PathPieces ( PathPiece(..) )
+
+------------------
+-- EmailAddress --
+------------------
 
 -- | Use 'EmailAddress' as a 'PersistField'.
 instance PersistField EmailAddress where
@@ -50,3 +56,18 @@ instance FromJSON EmailAddress where
 instance ToJSON EmailAddress where
     toJSON :: EmailAddress -> Value
     toJSON = String . decodeUtf8 . toByteString
+
+instance PathPiece EmailAddress where
+    fromPathPiece :: Text -> Maybe EmailAddress
+    fromPathPiece = emailAddress . encodeUtf8
+
+    toPathPiece :: EmailAddress -> Text
+    toPathPiece = decodeUtf8 . toByteString
+
+instance ToHttpApiData EmailAddress where
+    toUrlPiece :: EmailAddress -> Text
+    toUrlPiece = decodeUtf8 . toByteString
+
+instance FromHttpApiData EmailAddress where
+    parseUrlPiece :: Text -> Either Text EmailAddress
+    parseUrlPiece = first pack . validate . encodeUtf8

--- a/src/Kucipong/Prelude.hs
+++ b/src/Kucipong/Prelude.hs
@@ -10,6 +10,7 @@ import Control.Monad.Reader as X ( reader )
 import Control.Monad.Trans.Control as X ( MonadBaseControl )
 import Control.Monad.Trans.Identity as X ( IdentityT(..), runIdentityT )
 import Data.Data as X ( Data )
+import Data.Proxy as X ( Proxy(Proxy) )
 import Data.Word as X ( Word16 )
 import Text.Email.Validate as X ( EmailAddress )
 

--- a/src/Kucipong/Util.hs
+++ b/src/Kucipong/Util.hs
@@ -1,0 +1,10 @@
+
+module Kucipong.Util where
+
+import Kucipong.Prelude
+
+(<$$>) :: (Functor f, Functor g) => (a -> b) -> g (f a) -> g (f b)
+(<$$>) = fmap . fmap
+
+infixr 8 <$$>
+


### PR DESCRIPTION
Add definitions for common SQL tables.

This adds definitions for the following sql tables:
- `Admin`
- `CompanyEmail`
- `Company`
- `Coupon`
- `CouponDiscount`
- `CouponPresent`
- `CouponSet`

These sql tables are based on the [Kucipong 仕様](https://github.com/arowM/kucipong/blob/spec/doc/spec.md) document.
