### PR TITLE
Start adding authentication system.

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,10 @@
+-- The following hack is needed when using two packages, where one is
+-- ImplicitPrelude and one is NoImplicitPrelude.
+
+:set -XImplicitPrelude
+:add .stack-work/downloaded/7c431ba03e837f904d10866cd436267f4ab12d74e76fbf464e3599cab5e61d06/src/Text/Email/Validate.hs
+:add .stack-work/downloaded/2e6a2889ab218635d549c10132bf8206e87b52831bb0b0d63119ff59a8407377/Mail/Hailgun.hs
+:set -XNoImplicitPrelude
+-- :add src/Kucipong/Dev.hs
+:add src/Kucipong.hs
+-- import Kucipong.Dev

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dump-th:
 	@find "$$(stack path --dist-dir)" -name "*.dump-splices"
 
 ghci:
-	stack ghci
+	stack ghci --no-load
 
 haddock:
 	stack build --haddock
@@ -53,7 +53,7 @@ test:
 
 # Watch for changes.
 watch:
-	stack build --file-watch --fast .
+	stack build --file-watch --fast kucipong
 
 # Watch for changes.
 watch-test: watch-tests

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: build
 
 build:
-	stack build
+	stack build kucipong
 
 clean:
 	stack clean

--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ $ make run
 ### Other make target
 
 Look in the `Makefile` for other targets to run.
+
+## Add Admin User
+
+A new admin user can be added from the command line like the following.  The
+`KUCIPONG_MAILGUN_APIKEY` can be found by logging on to the mailgun website.
+This sends an email to the user so they can login as an admin.
+
+```bash
+$ make build
+$ export KUCIPONG_MAILGUN_APIKEY="key-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+$ stack exec -- kucipong-add-admin kucipong.dev@gmail.com "Some User Name"
+```

--- a/app/AddAdmin.hs
+++ b/app/AddAdmin.hs
@@ -1,0 +1,78 @@
+
+module Main where
+
+import Kucipong.Prelude
+
+import Control.Lens ( view )
+import Control.Monad.Time ( MonadTime(..) )
+import Database.Persist ( Entity(..) )
+import Options.Applicative
+    ( InfoMod, Parser, ParserInfo, ReadM, argument, eitherReader, execParser
+    , fullDesc, header, helper, info, metavar, progDesc, str
+    )
+import Text.Email.Validate ( validateFromString )
+
+import Kucipong.Config ( createConfigFromEnv )
+import Kucipong.Db ( adminLoginTokenLoginToken )
+import Kucipong.Monad
+    ( MonadKucipongDb(..), MonadKucipongSendEmail(..), runKucipongM )
+
+data AddAdminCommand = AddAdminCommand
+    { addAdminEmail :: EmailAddress
+    , addAdminName :: Text
+    }
+    deriving (Data, Eq, Generic, Show, Typeable)
+
+addAdmin
+    :: ( MonadKucipongDb m
+       , MonadKucipongSendEmail m
+       , MonadTime m
+       )
+    => EmailAddress -> Text -> m ()
+addAdmin email name = do
+    (Entity adminKey _) <- dbCreateAdmin email name
+    (Entity _ adminLoginToken) <- dbCreateAdminMagicLoginToken adminKey
+    let loginToken = view adminLoginTokenLoginToken adminLoginToken
+    sendAdminLoginEmail email loginToken
+
+run :: AddAdminCommand -> IO ()
+run (AddAdminCommand email name) = do
+    config <- createConfigFromEnv
+    res <- runKucipongM config $ addAdmin email name
+    case res of
+        Right () -> pure ()
+        Left appErr ->
+            putStrLn $ "Got app err: " <> tshow appErr
+
+-- | 'ReadM' parser for 'EmailAddress'.
+emailReadM :: ReadM EmailAddress
+emailReadM = eitherReader validateFromString
+
+-- | 'ReadM' parser for 'Text'.  Similar to 'str'.
+textReadM:: ReadM Text
+textReadM = pack <$> str
+
+addAdminCommandParser :: Parser AddAdminCommand
+addAdminCommandParser = AddAdminCommand <$> emailOption <*> nameOption
+  where
+    emailOption :: Parser EmailAddress
+    emailOption = argument emailReadM $ metavar "ADMIN_EMAIL"
+
+    nameOption :: Parser Text
+    nameOption = argument textReadM $ metavar "ADMIN_NAME"
+
+main :: IO ()
+main = execParser topOpts >>= run
+  where
+    topOpts :: ParserInfo AddAdminCommand
+    topOpts = info (helper <*> addAdminCommandParser) topDesc
+
+    topDesc :: InfoMod AddAdminCommand
+    topDesc =
+        let headerMsg = "kucipong-add-admin - add a new admin user"
+            progDescMsg =
+                "Add a new admin user to the database and send them an " <>
+                "email they can use to login."
+        in fullDesc `mappend`
+            progDesc progDescMsg `mappend`
+            header headerMsg

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -23,6 +23,7 @@ library
                      , Kucipong.Db.Models.EntityDefs
                      , Kucipong.Db.Pool
                      , Kucipong.Db.Run
+                     , Kucipong.Email
                      , Kucipong.Environment
                      , Kucipong.Errors
                      , Kucipong.Handler
@@ -39,6 +40,7 @@ library
                      , classy-prelude
                      , email-validate
                      , envelope
+                     , hailgun
                      , http-api-data
                      , http-client
                      , http-conduit

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -38,7 +38,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , aeson
                      , classy-prelude
-                     , email-validate
+                     , emailaddress
                      , envelope
                      , hailgun
                      , http-api-data

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -27,11 +27,17 @@ library
                      , Kucipong.Environment
                      , Kucipong.Errors
                      , Kucipong.Handler
+                     , Kucipong.LoginToken
                      , Kucipong.Monad
                      , Kucipong.Monad.Db
                      , Kucipong.Monad.Db.Class
                      , Kucipong.Monad.Db.Instance
                      , Kucipong.Monad.Db.Trans
+                     , Kucipong.Monad.OtherInstances
+                     , Kucipong.Monad.SendEmail
+                     , Kucipong.Monad.SendEmail.Class
+                     , Kucipong.Monad.SendEmail.Instance
+                     , Kucipong.Monad.SendEmail.Trans
                      , Kucipong.Orphans
                      , Kucipong.Prelude
                      , Kucipong.Util
@@ -47,6 +53,8 @@ library
                      , lens
                      , monad-control
                      , monad-logger
+                     , MonadRandom
+                     , monad-time
                      , mtl
                      , path-pieces
                      , persistent
@@ -56,6 +64,7 @@ library
                      , pwstore-fast
                      , read-env-var
                      , resource-pool
+                     , shakespeare
                      , Spock
                      , time
                      , transformers
@@ -111,6 +120,45 @@ executable kucipong
                      , GeneralizedNewtypeDeriving
                      , InstanceSigs
                      , MultiParamTypeClasses
+                     , NoImplicitPrelude
+                     , OverloadedStrings
+                     , PolyKinds
+                     , RankNTypes
+                     , RecordWildCards
+                     , ScopedTypeVariables
+                     , StandaloneDeriving
+                     , TupleSections
+                     , TypeFamilies
+                     , TypeOperators
+  other-extensions:    QuasiQuotes
+                     , TemplateHaskell
+
+executable kucipong-add-admin
+  hs-source-dirs:      app
+  main-is:             AddAdmin.hs
+  ghc-options:         -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , kucipong
+                     , emailaddress
+                     , lens
+                     , monad-time
+                     , optparse-applicative
+                     , persistent
+  default-language:    Haskell2010
+  default-extensions:  ConstraintKinds
+                     , DataKinds
+                     , DefaultSignatures
+                     , DeriveDataTypeable
+                     , DeriveFunctor
+                     , DeriveGeneric
+                     , EmptyDataDecls
+                     , FlexibleContexts
+                     , FlexibleInstances
+                     , GADTs
+                     , GeneralizedNewtypeDeriving
+                     , InstanceSigs
+                     , MultiParamTypeClasses
+                     , NamedFieldPuns
                      , NoImplicitPrelude
                      , OverloadedStrings
                      , PolyKinds

--- a/src/Kucipong/Config.hs
+++ b/src/Kucipong/Config.hs
@@ -8,23 +8,25 @@ import Kucipong.Prelude
 import Control.Monad.Logger ( runStdoutLoggingT )
 import Database.Persist.Postgresql ( ConnectionPool )
 import Database.PostgreSQL.Simple ( ConnectInfo(..) )
+import Mail.Hailgun ( HailgunContext(..) )
 import Network.HTTP.Client ( Manager, newManager )
 import Network.HTTP.Client.Conduit ( HasHttpManager(..) )
 import Network.HTTP.Conduit (tlsManagerSettings)
 import Network.Wai.Handler.Warp ( Port )
 import Network.Wai.Middleware.RequestLogger ( logStdoutDev, logStdout )
 import Network.Wai ( Middleware )
-import System.ReadEnvVar ( readEnvVarDef )
+import System.ReadEnvVar ( lookupEnvDef, readEnvVarDef )
 
 import Kucipong.Environment ( Environment(..), HasEnv(..) )
+import Kucipong.Email ( HasHailgunContext(..) )
 import Kucipong.Db
     ( DbPoolConnNum, DbPoolConnTimeout, HasDbPool(..), makePool )
 
--- | Create an SQL 'ConnectionPool'.
 -- | A 'Config' used by our application.  It contains things used
 -- throughout a request.
 data Config = Config
     { configEnv  :: Environment
+    , configHailgunContext :: HailgunContext
     , configHttpManager :: Manager
     , configPool :: ConnectionPool
     , configPort :: Port
@@ -40,6 +42,10 @@ instance HasDbPool Config where
 instance HasEnv Config where
     getEnv :: Config -> Environment
     getEnv = configEnv
+
+instance HasHailgunContext Config where
+    getHailgunContext :: Config -> HailgunContext
+    getHailgunContext = configHailgunContext
 
 instance HasHttpManager Config where
     getHttpManager :: Config -> Manager
@@ -75,15 +81,17 @@ createConfigFromEnv :: IO Config
 createConfigFromEnv = do
     env <- readEnvVarDef "KUCIPONG_ENV" Development
     port <- readEnvVarDef "KUCIPONG_PORT" 8101
+    hailgunContextDomain <- lookupEnvDef "KUCIPONG_MAILGUN_DOMAIN" "sandboxfaf3e17ba66f42a5ac5cd36e8a71ad97.mailgun.org"
+    hailgunContextApiKey <- lookupEnvDef "KUCIPONG_MAILGUN_APIKEY" "todo-fake-apikey"
     dbConnNum <- readEnvVarDef "KUCIPONG_DB_CONN_NUM" 10
     dbConnTimeout <- fromInteger <$> readEnvVarDef "KUCIPONG_DB_CONN_TIMEOUT" 60 -- 1 minute
-    dbHost <- readEnvVarDef "KUCIPONG_DB_HOST" "localhost"
+    dbHost <- lookupEnvDef "KUCIPONG_DB_HOST" "localhost"
     dbPort <- readEnvVarDef "KUCIPONG_DB_PORT" 5432
-    dbUser <- readEnvVarDef "KUCIPONG_DB_USER" "kucipong"
-    dbPass <- readEnvVarDef "KUCIPONG_DB_PASSWORD" "nuy07078akyy1y7anvya7072"
-    dbDatabase <- readEnvVarDef "KUCIPONG_DB_DATABASE" "kucipong"
-    createConfigFromValues
-        env port dbConnNum dbConnTimeout dbHost dbPort dbUser dbPass dbDatabase
+    dbUser <- lookupEnvDef "KUCIPONG_DB_USER" "kucipong"
+    dbPass <- lookupEnvDef "KUCIPONG_DB_PASSWORD" "nuy07078akyy1y7anvya7072"
+    dbDatabase <- lookupEnvDef "KUCIPONG_DB_DATABASE" "kucipong"
+    createConfigFromValues env port hailgunContextDomain hailgunContextApiKey
+        dbConnNum dbConnTimeout dbHost dbPort dbUser dbPass dbDatabase
 
 type DbHost = String
 type DbPort = Word16
@@ -91,9 +99,14 @@ type DbUser = String
 type DbPassword = String
 type DbName = String
 
+type HailgunDomain = String
+type HailgunApiKey = String
+
 createConfigFromValues
     :: Environment
     -> Port
+    -> HailgunDomain
+    -> HailgunApiKey
     -> DbPoolConnNum
     -> DbPoolConnTimeout
     -> DbHost
@@ -102,8 +115,14 @@ createConfigFromValues
     -> DbPassword
     -> DbName
     -> IO Config
-createConfigFromValues env port dbConnNum dbConnTimeout dbHost dbPort dbUser dbPass dbName = do
+createConfigFromValues env port hailgunContextDomain hailgunContextApiKey
+        dbConnNum dbConnTimeout dbHost dbPort dbUser dbPass dbName = do
     httpManager <- newManager tlsManagerSettings
+    let hailgunContext = HailgunContext
+            { hailgunDomain = hailgunContextDomain
+            , hailgunApiKey = hailgunContextApiKey
+            , hailgunProxy = Nothing
+            }
     let dbConnInfo = ConnectInfo
             { connectHost = dbHost
             , connectPort = dbPort
@@ -115,6 +134,7 @@ createConfigFromValues env port dbConnNum dbConnTimeout dbHost dbPort dbUser dbP
     pure Config
         { configPool = pool
         , configEnv = env
+        , configHailgunContext = hailgunContext
         , configHttpManager = httpManager
         , configPort = port
         }

--- a/src/Kucipong/Db/Models.hs
+++ b/src/Kucipong/Db/Models.hs
@@ -19,9 +19,10 @@ import Database.Persist.TH (
     )
 
 import Kucipong.Db.Models.Base
-    ( CouponType, CreatedTime, DeletedTime, Image, Percent, Price, UpdatedTime
-    )
+    ( CouponType, CreatedTime(..), DeletedTime(..), Image
+    , LoginTokenExpirationTime(..), Percent, Price, UpdatedTime(..) )
 import Kucipong.Db.Models.EntityDefs ( kucipongEntityDefs )
+import Kucipong.LoginToken ( LoginToken )
 
 share [ mkPersist sqlSettings { mpsGenerateLenses = True }
       , mkMigrate "migrateAll"

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -69,6 +69,16 @@ newtype Image = Image { unImage :: Text }
         ( Data, Eq, FromJSON, Generic, Ord, PersistField, PersistFieldSql, Show
         , ToJSON, Typeable )
 
+---------------------------------
+-- Login Token Expiration Time --
+---------------------------------
+
+newtype LoginTokenExpirationTime = LoginTokenExpirationTime
+    { unLoginTokenExpirationTime :: UTCTime }
+    deriving
+        ( Data, Eq, FromJSON, Generic, Ord, PersistField, PersistFieldSql, Show
+        , ToJSON, Typeable )
+
 -------------
 -- Percent --
 -------------

--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -8,7 +8,9 @@ import Database.Persist ( EntityDef )
 import Database.Persist.TH ( persistLowerCase )
 
 import Kucipong.Db.Models.Base
-    ( CouponType, CreatedTime, DeletedTime, Image, Percent, Price, UpdatedTime )
+    ( CouponType, CreatedTime, DeletedTime, Image, LoginTokenExpirationTime
+    , Percent, Price, UpdatedTime )
+import Kucipong.LoginToken ( LoginToken )
 
 kucipongEntityDefs :: [EntityDef]
 kucipongEntityDefs = [persistLowerCase|
@@ -18,6 +20,20 @@ kucipongEntityDefs = [persistLowerCase|
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe
         name                    Text
+
+        Primary email
+
+        deriving Eq
+        deriving Show
+        deriving Typeable
+
+    AdminLoginToken
+        email                   AdminId
+        created                 CreatedTime
+        updated                 UpdatedTime
+        deleted                 DeletedTime Maybe
+        loginToken              LoginToken
+        expirationTime          LoginTokenExpirationTime
 
         Primary email
 

--- a/src/Kucipong/Email.hs
+++ b/src/Kucipong/Email.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE QuasiQuotes #-}
 
 module Kucipong.Email where
 
@@ -8,8 +9,10 @@ import Mail.Hailgun
     , HailgunMessage, HailgunSendResponse, MessageContent(..)
     , MessageRecipients(..), emptyMessageRecipients, hailgunMessage, sendEmail )
 import Text.Email.Validate ( toByteString )
+import Text.Shakespeare.Text ( st )
 
 import Kucipong.Errors ( AppErr, AppErrEnum(..), throwAppErr )
+import Kucipong.LoginToken ( LoginToken(..) )
 
 class HasHailgunContext r where
     getHailgunContext :: r -> HailgunContext
@@ -17,18 +20,28 @@ class HasHailgunContext r where
 instance HasHailgunContext HailgunContext where
     getHailgunContext = id
 
-sendRegistrationCompletedEmail
+-- | Generic method for sending an email.  It takes an 'Either'
+-- 'HailgunErrorMessage' 'HailgunMessage'.
+--
+-- If the value is 'Left' 'HailgunErrorMessage', then throw an
+-- 'OtherException'.  Normally it will not be 'Left', because we are creating
+-- the 'HailgunMessage' by hand.
+--
+-- If the value is 'Right' 'HailgunMessage', then call 'sendEmail'' with the
+-- message. 'sendEmail'' may throw a 'HailgunErrorResponse'.  Rethrow this as
+-- an 'AppErr' ('HailgunError').
+sendEmailGeneric
     :: forall r m
      . ( HasHailgunContext r
        , MonadError AppErr m
        , MonadIO m
        , MonadReader r m
        )
-    => EmailAddress -> m HailgunSendResponse
-sendRegistrationCompletedEmail companyEmail = do
+    => Either HailgunErrorMessage HailgunMessage
+    -> m HailgunSendResponse
+sendEmailGeneric createMessageResult = do
     hailgunContext <- reader getHailgunContext
-    either handleMessageError (trySendEmail hailgunContext) $
-        registrationCompleteMessage companyEmail
+    either handleMessageError (trySendEmail hailgunContext) createMessageResult
   where
     handleMessageError :: String -> m a
     handleMessageError = throwAppErr OtherException . Just . pack
@@ -39,6 +52,48 @@ sendRegistrationCompletedEmail companyEmail = do
     trySendEmail :: HailgunContext -> HailgunMessage -> m HailgunSendResponse
     trySendEmail hailgunContext =
         either handleSendError pure <=< sendEmail' hailgunContext
+
+sendAdminLoginEmail
+    :: forall r m
+     . ( HasHailgunContext r
+       , MonadError AppErr m
+       , MonadIO m
+       , MonadReader r m
+       )
+    => EmailAddress
+    -> LoginToken
+    -> m HailgunSendResponse
+sendAdminLoginEmail = (sendEmailGeneric .) . adminLoginMsg
+
+adminLoginMsg :: EmailAddress -> LoginToken -> Either HailgunErrorMessage HailgunMessage
+adminLoginMsg adminEmail url =
+    let subject = "Kucipong Admin Login"
+        content = TextOnly $ encodeUtf8 textContent
+        replyTo = "no-reply@kucipong.com"
+        to = toByteString adminEmail
+        recipients = emptyMessageRecipients { recipientsTo = [ to ] }
+        attachements = []
+    in hailgunMessage subject content replyTo recipients attachements
+  where
+    textContent :: Text
+    textContent =
+        [st|
+             This is an email from Kucipong.  You can use the following URL to
+             login as an admin:
+
+             TODO: Actually add login email here.
+        |]
+
+
+sendRegistrationCompletedEmail
+    :: forall r m
+     . ( HasHailgunContext r
+       , MonadError AppErr m
+       , MonadIO m
+       , MonadReader r m
+       )
+    => EmailAddress -> m HailgunSendResponse
+sendRegistrationCompletedEmail = sendEmailGeneric . registrationCompleteMessage
 
 registrationCompleteMessage :: EmailAddress -> Either HailgunErrorMessage HailgunMessage
 registrationCompleteMessage companyEmail =

--- a/src/Kucipong/Email.hs
+++ b/src/Kucipong/Email.hs
@@ -1,0 +1,10 @@
+
+module Kucipong.Email where
+
+import Kucipong.Prelude
+
+import Mail.Hailgun
+
+-- sendRegistrationCompletedEmail :: MonadIO m => m ()
+-- sendRegistrationCompletedEmail =
+--     sendEmail

--- a/src/Kucipong/Email.hs
+++ b/src/Kucipong/Email.hs
@@ -4,7 +4,55 @@ module Kucipong.Email where
 import Kucipong.Prelude
 
 import Mail.Hailgun
+    ( HailgunContext, HailgunErrorMessage, HailgunErrorResponse(..)
+    , HailgunMessage, HailgunSendResponse, MessageContent(..)
+    , MessageRecipients(..), emptyMessageRecipients, hailgunMessage, sendEmail )
+import Text.Email.Validate ( toByteString )
 
--- sendRegistrationCompletedEmail :: MonadIO m => m ()
--- sendRegistrationCompletedEmail =
---     sendEmail
+import Kucipong.Errors ( AppErr, AppErrEnum(..), throwAppErr )
+
+class HasHailgunContext r where
+    getHailgunContext :: r -> HailgunContext
+
+instance HasHailgunContext HailgunContext where
+    getHailgunContext = id
+
+sendRegistrationCompletedEmail
+    :: forall r m
+     . ( HasHailgunContext r
+       , MonadError AppErr m
+       , MonadIO m
+       , MonadReader r m
+       )
+    => EmailAddress -> m HailgunSendResponse
+sendRegistrationCompletedEmail companyEmail = do
+    hailgunContext <- reader getHailgunContext
+    either handleMessageError (trySendEmail hailgunContext) $
+        registrationCompleteMessage companyEmail
+  where
+    handleMessageError :: String -> m a
+    handleMessageError = throwAppErr OtherException . Just . pack
+
+    handleSendError :: HailgunErrorResponse -> m a
+    handleSendError = throwAppErr HailgunError . Just . pack . herMessage
+
+    trySendEmail :: HailgunContext -> HailgunMessage -> m HailgunSendResponse
+    trySendEmail hailgunContext =
+        either handleSendError pure <=< sendEmail' hailgunContext
+
+registrationCompleteMessage :: EmailAddress -> Either HailgunErrorMessage HailgunMessage
+registrationCompleteMessage companyEmail =
+    let subject = "test subject"
+        content = TextOnly "test content"
+        replyTo = "info@kucipong.com"
+        to = toByteString companyEmail
+        recipients = emptyMessageRecipients { recipientsTo = [ to ] }
+        attachements = []
+    in hailgunMessage subject content replyTo recipients attachements
+
+sendEmail'
+    :: MonadIO m
+    => HailgunContext
+    -> HailgunMessage
+    -> m (Either HailgunErrorResponse HailgunSendResponse)
+sendEmail' = (liftIO .) . sendEmail

--- a/src/Kucipong/Errors.hs
+++ b/src/Kucipong/Errors.hs
@@ -16,6 +16,8 @@ instance Exception AppErr
 data AppErrEnum
     = AuthErr
     -- ^ An error with auth.
+    | HailgunError
+    -- ^ An error with sending an email to hailgun.
     | OtherException
     -- ^ A wrapper for any other type of exception
     | SessionExpired

--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -8,6 +8,11 @@ import Web.Spock ( Path, (<//>), get, html, root, runSpock, spockT, text, var )
 import Kucipong.Config ( Config, HasPort(..) )
 import Kucipong.Monad ( KucipongM, runKucipongM )
 
+-- TODO: Remove this:
+import Kucipong.Email
+import Mail.Hailgun
+import Text.Email.Validate (emailAddress)
+
 helloR :: Path '[Text]
 helloR = "hello" <//> var
 
@@ -24,4 +29,12 @@ app config = runSpock (getPort config) $
             -- dbLoginUser undefined undefined
             html "<p>hello world</p>"
         get helloR $ \name -> text $ "Hello " <> name <> "!"
-        get addR $ \a b -> text $ pack $ show (a + b)
+        get addR $ \a b -> text . pack $ show (a + b)
+        -- TODO: Remove this.  This is just an example of how to send email.
+        get "sendemail" $ do
+            res <- liftIO $ runKucipongM config $ do
+                mailgunContext <- reader getHailgunContext
+                print mailgunContext
+                resp <- sendRegistrationCompletedEmail (fromMaybe undefined $ emailAddress "kucipong.dev@gmail.com")
+                print resp
+            print res

--- a/src/Kucipong/LoginToken.hs
+++ b/src/Kucipong/LoginToken.hs
@@ -1,0 +1,14 @@
+
+module Kucipong.LoginToken where
+
+import Kucipong.Prelude
+
+import Control.Monad.Random ( MonadRandom, getRandoms )
+import Database.Persist ( PersistField(..) )
+import Database.Persist.Sql ( PersistFieldSql(..) )
+
+newtype LoginToken = LoginToken { unLoginToken :: Text }
+    deriving (Data, Eq, Generic, PersistField, PersistFieldSql, Show, Typeable)
+
+createRandomLoginToken :: MonadRandom m => m LoginToken
+createRandomLoginToken = LoginToken . pack . take 50 <$> getRandoms

--- a/src/Kucipong/Monad.hs
+++ b/src/Kucipong/Monad.hs
@@ -32,6 +32,7 @@ type MonadKucipong m =
     , MonadKucipong' m
     )
 
+-- | 'KucipongT' is just a wrapper around all of our Monad transformers.
 newtype KucipongT m a = KucipongT
     { unKucipongT ::
         KucipongDbT m a
@@ -55,11 +56,13 @@ deriving instance
     ) => MonadKucipongDb (KucipongT m)
 
 
+-- | Unwrap the @m@ from 'KucipongT'.
 runKucipongT :: KucipongT m a -> m a
 runKucipongT =
       runKucipongDbT
     . unKucipongT
 
+-- | Lift an action in @m@ to 'KucipongT'.
 liftToKucipongT :: (Monad m) => m a -> KucipongT m a
 liftToKucipongT = KucipongT . lift
 
@@ -80,6 +83,7 @@ instance (MonadBaseControl b m) => MonadBaseControl b (KucipongT m) where
     {-# INLINABLE liftBaseWith #-}
     {-# INLINABLE restoreM #-}
 
+-- | Monad transformer stack for our application.
 newtype KucipongM a = KucipongM
     { unKucipongM ::
         KucipongT (ReaderT Config (ExceptT AppErr (LoggingT IO))) a
@@ -116,6 +120,7 @@ instance MonadBaseControl IO KucipongM where
         readerT :: ReaderT Config (ExceptT AppErr (LoggingT IO)) a
         readerT = ReaderT $ \config -> ExceptT . lift $ f config
 
+-- | Run the 'KucipongM' monad stack.
 runKucipongM :: Config -> KucipongM a -> IO (Either AppErr a)
 runKucipongM config =
       runStdoutLoggingT

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -9,6 +9,11 @@ import Web.Spock ( ActionCtxT )
 
 import Kucipong.Db ( Admin, Key )
 
+-- | Type-class for monads that can perform Db actions.  For instance, querying
+-- the database for information or writing new information to the database.
+--
+-- Default implementations are used to easily derive instances for monads
+-- transformers that implement 'MonadTrans'.
 class Monad m => MonadKucipongDb m where
     dbInsertNewUser :: EmailAddress -> m (Key Admin)
     default dbInsertNewUser

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -5,9 +5,10 @@ module Kucipong.Monad.Db.Class where
 import Kucipong.Prelude
 
 import Control.Monad.Trans ( MonadTrans )
+import Database.Persist ( Entity )
 import Web.Spock ( ActionCtxT )
 
-import Kucipong.Db ( Admin, Key )
+import Kucipong.Db ( Admin, AdminLoginToken, Key )
 
 -- | Type-class for monads that can perform Db actions.  For instance, querying
 -- the database for information or writing new information to the database.
@@ -15,25 +16,29 @@ import Kucipong.Db ( Admin, Key )
 -- Default implementations are used to easily derive instances for monads
 -- transformers that implement 'MonadTrans'.
 class Monad m => MonadKucipongDb m where
-    dbInsertNewUser :: EmailAddress -> m (Key Admin)
-    default dbInsertNewUser
+    dbCreateAdmin
+        :: EmailAddress
+        -> Text
+        -- ^ Admin name
+        -> m (Entity Admin)
+    default dbCreateAdmin
         :: ( Monad (t n)
            , MonadKucipongDb n
            , MonadTrans t
            , m ~ t n
            )
-        => EmailAddress -> t n (Key Admin)
-    dbInsertNewUser = lift . dbInsertNewUser
+        => EmailAddress -> Text -> t n (Entity Admin)
+    dbCreateAdmin = (lift .) . dbCreateAdmin
 
-    dbLoginUser :: EmailAddress -> m (Maybe (Key Admin))
-    default dbLoginUser
+    dbCreateAdminMagicLoginToken :: Key Admin -> m (Entity AdminLoginToken)
+    default dbCreateAdminMagicLoginToken
         :: ( Monad (t n)
            , MonadKucipongDb n
            , MonadTrans t
            , m ~ t n
            )
-        => EmailAddress -> t n (Maybe (Key Admin))
-    dbLoginUser = lift . dbLoginUser
+        => Key Admin -> t n (Entity AdminLoginToken)
+    dbCreateAdminMagicLoginToken = lift . dbCreateAdminMagicLoginToken
 
 instance MonadKucipongDb m => MonadKucipongDb (ExceptT e m)
 instance MonadKucipongDb m => MonadKucipongDb (IdentityT m)

--- a/src/Kucipong/Monad/OtherInstances.hs
+++ b/src/Kucipong/Monad/OtherInstances.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Kucipong.Monad.OtherInstances where
+
+import Kucipong.Prelude
+
+import Control.Monad.Random ( MonadRandom(..) )
+
+instance MonadRandom m => MonadRandom (LoggingT m) where
+    getRandom = lift getRandom
+    getRandomR = lift . getRandomR
+    getRandoms = lift getRandoms
+    getRandomRs = lift . getRandomRs
+

--- a/src/Kucipong/Monad/SendEmail.hs
+++ b/src/Kucipong/Monad/SendEmail.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Kucipong.Monad.SendEmail ( module X ) where
+
+import Kucipong.Monad.SendEmail.Class as X
+import Kucipong.Monad.SendEmail.Instance as X ()
+import Kucipong.Monad.SendEmail.Trans as X

--- a/src/Kucipong/Monad/SendEmail/Class.hs
+++ b/src/Kucipong/Monad/SendEmail/Class.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DefaultSignatures #-}
+
+module Kucipong.Monad.SendEmail.Class where
+
+import Kucipong.Prelude
+
+import Control.Monad.Trans ( MonadTrans )
+import Web.Spock ( ActionCtxT )
+
+import Kucipong.LoginToken ( LoginToken )
+import Kucipong.Monad.Db.Trans ( KucipongDbT )
+
+-- |
+-- Default implementations are used to easily derive instances for monads
+-- transformers that implement 'MonadTrans'.
+class Monad m => MonadKucipongSendEmail m where
+    sendAdminLoginEmail
+        :: EmailAddress
+        -> LoginToken
+        -> m ()
+    default sendAdminLoginEmail
+        :: ( Monad (t n)
+           , MonadKucipongSendEmail n
+           , MonadTrans t
+           , m ~ t n
+           )
+        => EmailAddress -> LoginToken -> t n ()
+    sendAdminLoginEmail = (lift .) . sendAdminLoginEmail
+
+instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ExceptT e m)
+instance MonadKucipongSendEmail m => MonadKucipongSendEmail (IdentityT m)
+instance MonadKucipongSendEmail m => MonadKucipongSendEmail (KucipongDbT m)
+instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ReaderT r m)
+instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ActionCtxT ctx m)

--- a/src/Kucipong/Monad/SendEmail/Instance.hs
+++ b/src/Kucipong/Monad/SendEmail/Instance.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Kucipong.Monad.SendEmail.Instance where
+
+import Kucipong.Prelude
+
+import Kucipong.Email ( HasHailgunContext )
+import qualified Kucipong.Email as Email
+import Kucipong.Errors ( AppErr )
+import Kucipong.LoginToken ( LoginToken )
+import Kucipong.Monad.SendEmail.Class ( MonadKucipongSendEmail(..) )
+import Kucipong.Monad.SendEmail.Trans ( KucipongSendEmailT(..) )
+
+instance
+    ( HasHailgunContext r
+    , MonadError AppErr m
+    , MonadIO m
+    , MonadReader r m
+    ) => MonadKucipongSendEmail (KucipongSendEmailT m) where
+
+    sendAdminLoginEmail :: EmailAddress -> LoginToken -> KucipongSendEmailT m ()
+    sendAdminLoginEmail = (void .) . Email.sendAdminLoginEmail

--- a/src/Kucipong/Monad/SendEmail/Trans.hs
+++ b/src/Kucipong/Monad/SendEmail/Trans.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
-module Kucipong.Monad.Db.Trans where
+module Kucipong.Monad.SendEmail.Trans where
 
 import Kucipong.Prelude
 
@@ -11,7 +11,8 @@ import Control.Monad.Trans.Control
     ( ComposeSt, MonadBaseControl(..), MonadTransControl(..)
     , defaultLiftBaseWith, defaultRestoreM )
 
-newtype KucipongDbT m a = KucipongDbT { unKucipongDbT :: IdentityT m a }
+
+newtype KucipongSendEmailT m a = KucipongSendEmailT { unKucipongSendEmailT :: IdentityT m a }
     deriving
         ( Applicative
         , Functor
@@ -26,18 +27,18 @@ newtype KucipongDbT m a = KucipongDbT { unKucipongDbT :: IdentityT m a }
         , MonadTrans
         )
 
-runKucipongDbT :: KucipongDbT m a -> m a
-runKucipongDbT = runIdentityT . unKucipongDbT
+runKucipongSendEmailT :: KucipongSendEmailT m a -> m a
+runKucipongSendEmailT = runIdentityT . unKucipongSendEmailT
 
-instance MonadTransControl KucipongDbT where
-    type StT KucipongDbT a = a
-    liftWith f = lift (f runKucipongDbT)
-    restoreT = KucipongDbT . IdentityT
+instance MonadTransControl KucipongSendEmailT where
+    type StT KucipongSendEmailT a = a
+    liftWith f = lift (f runKucipongSendEmailT)
+    restoreT = KucipongSendEmailT . IdentityT
     {-# INLINABLE liftWith #-}
     {-# INLINABLE restoreT #-}
 
-instance (MonadBaseControl b m) => MonadBaseControl b (KucipongDbT m) where
-    type StM (KucipongDbT m) a = ComposeSt KucipongDbT m a
+instance (MonadBaseControl b m) => MonadBaseControl b (KucipongSendEmailT m) where
+    type StM (KucipongSendEmailT m) a = ComposeSt KucipongSendEmailT m a
     liftBaseWith = defaultLiftBaseWith
     restoreM     = defaultRestoreM
     {-# INLINABLE liftBaseWith #-}

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -6,68 +6,9 @@ Description : Orphan instances
 This is a hack to make orphan instances of some of the types we use.  This file
 will mostly be making persistent ('PersistField' and 'PersistFieldSql') and
 aeson ('FromJSON' and 'ToJSON') instances for types we use that are defined in
-other libraries (such as 'EmailAddress') but that we us here.
+other libraries but that we use here.
 -}
 
 module Kucipong.Orphans where
 
 import ClassyPrelude
-
-import Data.Aeson ( ToJSON(..), FromJSON(..), Value(..), withText )
-import Data.Aeson.Types ( Parser )
-import Data.Proxy ( Proxy )
-import Database.Persist.Postgresql
-    ( PersistField(..), PersistFieldSql(..), PersistValue(..), SqlType(..))
-import Text.Email.Validate ( EmailAddress, emailAddress, toByteString, validate )
-import Web.HttpApiData ( FromHttpApiData(..), ToHttpApiData(..) )
-import Web.PathPieces ( PathPiece(..) )
-
-------------------
--- EmailAddress --
-------------------
-
--- | Use 'EmailAddress' as a 'PersistField'.
-instance PersistField EmailAddress where
-    toPersistValue :: EmailAddress -> PersistValue
-    toPersistValue = PersistText . decodeUtf8 . toByteString
-
-    fromPersistValue :: PersistValue -> Either Text EmailAddress
-    fromPersistValue (PersistText text) =
-        first pack . validate $ encodeUtf8 text
-    fromPersistValue x = Left $
-        "unexpected value (" <> tshow x <>
-            ") in fromPersistValue in EmailAddress instance for PersistField"
-
--- | Use 'EmailAddress' as a 'PersistField'.
-instance PersistFieldSql EmailAddress where
-    sqlType :: Proxy EmailAddress -> SqlType
-    sqlType _ = SqlString
-
--- | Turn 'EmailAddress' into JSON.
-instance FromJSON EmailAddress where
-    parseJSON :: Value -> Parser EmailAddress
-    parseJSON = withText "EmailAddress" $ \t ->
-                    case validate $ encodeUtf8 t of
-                        Left err -> fail $ "Failed to parse email address: " <> err
-                        Right email -> return email
-    {-# INLINE parseJSON #-}
-
--- | Turn 'EmailAddress' into JSON.
-instance ToJSON EmailAddress where
-    toJSON :: EmailAddress -> Value
-    toJSON = String . decodeUtf8 . toByteString
-
-instance PathPiece EmailAddress where
-    fromPathPiece :: Text -> Maybe EmailAddress
-    fromPathPiece = emailAddress . encodeUtf8
-
-    toPathPiece :: EmailAddress -> Text
-    toPathPiece = decodeUtf8 . toByteString
-
-instance ToHttpApiData EmailAddress where
-    toUrlPiece :: EmailAddress -> Text
-    toUrlPiece = decodeUtf8 . toByteString
-
-instance FromHttpApiData EmailAddress where
-    parseUrlPiece :: Text -> Either Text EmailAddress
-    parseUrlPiece = first pack . validate . encodeUtf8

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -10,5 +10,3 @@ other libraries but that we use here.
 -}
 
 module Kucipong.Orphans where
-
-import ClassyPrelude

--- a/src/Kucipong/Util.hs
+++ b/src/Kucipong/Util.hs
@@ -3,8 +3,20 @@ module Kucipong.Util where
 
 import Kucipong.Prelude
 
+import Data.Time.Clock ( NominalDiffTime, addUTCTime )
+
+-- | Double 'fmap'.
+--
+-- >>> succ <$$> Just (Just 3)
+-- Just (Just 4)
 (<$$>) :: (Functor f, Functor g) => (a -> b) -> g (f a) -> g (f b)
 (<$$>) = fmap . fmap
 
 infixr 8 <$$>
 
+oneDay :: NominalDiffTime
+oneDay = 60 * 60 * 24
+
+-- | Add one day to a 'UTCTime'.
+addOneDay :: UTCTime -> UTCTime
+addOneDay = addUTCTime oneDay

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,21 +2,17 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-6.10
+resolver: lts-6.13
 
 # Local packages, usually specified by relative directory name
 packages:
     - '.'
     # TODO: This was added here: https://github.com/fpco/stackage/pull/1782
-    # Hopefull we'll be able to use it when lts-6.13 comes out.  It should be
-    # out sometime before 2016/09/01.
+    # Hopefull we'll be able to use it when lts-6.14 comes out.  It should be
+    # out sometime around 2016/09/01.
     - location:
         git: 'https://bitbucket.org/cdepillabout/hailgun'
         commit: '275a4ebdeab79f7fb048e6174ca2f2bf75aa1f71' # derive-show branch
-    # TODO: This should also be in lts-6.13.
-    - location:
-        git: 'https://github.com/cdepillabout/read-env-var'
-        commit: 'v0.1.0.1'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,9 +6,14 @@ resolver: lts-6.10
 
 # Local packages, usually specified by relative directory name
 packages:
-- '.'
+    - '.'
+
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+    # TODO: This was added here: https://github.com/fpco/stackage/pull/1782
+    # Hopefull we'll be able to use it when lts-6.13 comes out.  It should be
+    # out sometime before 2016/09/01.
+    - hailgun-0.4.0.5
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,9 +13,21 @@ packages:
     - location:
         git: 'https://bitbucket.org/cdepillabout/hailgun'
         commit: '275a4ebdeab79f7fb048e6174ca2f2bf75aa1f71' # derive-show branch
+    # TODO: This will probably be in stackage lts-6.14.  It can get removed
+    # then.  Also, it can get pushed down to the "extra-deps" section sometime
+    # after 8/23.  It can't be done immediately because stack's hackage
+    # databases only update every 24 hours.
+    - location:
+        git: 'https://github.com/cdepillabout/emailaddress'
+        commit: v0.1.6.0
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps: []
+    # This will probably be in lts-6.14.
+    # - emailaddress-0.1.6.0
+    # This will probably be available sometime after 8/22 in hackage, and in
+    # lts-6.14.
+    # - hailgun-0.4.1.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,13 +7,19 @@ resolver: lts-6.10
 # Local packages, usually specified by relative directory name
 packages:
     - '.'
-
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
     # TODO: This was added here: https://github.com/fpco/stackage/pull/1782
     # Hopefull we'll be able to use it when lts-6.13 comes out.  It should be
     # out sometime before 2016/09/01.
-    - hailgun-0.4.0.5
+    - location:
+        git: 'https://bitbucket.org/cdepillabout/hailgun'
+        commit: '275a4ebdeab79f7fb048e6174ca2f2bf75aa1f71' # derive-show branch
+    # TODO: This should also be in lts-6.13.
+    - location:
+        git: 'https://github.com/cdepillabout/read-env-var'
+        commit: 'v0.1.0.1'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This PR adds a command-line program that is able to add an Admin user.

It adds the Admin user to the database, and then sends them an email they can use to login.

The functionality of actually logging in the admin user is not implemented yet.

@arowM @kayhide Please review.

The main files for reviewing are `app/AddAdmin.hs`, `src/Kucipong/Db/Models/EntityDefs.hs`,  `src/Kucipong/Email.hs`, and `src/Kucipong/Monad/Db/Instance.hs`.
