### PR TITLE
Auth implementation

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,10 +1,10 @@
 -- The following hack is needed when using two packages, where one is
 -- ImplicitPrelude and one is NoImplicitPrelude.
 
-:set -XImplicitPrelude
-:add .stack-work/downloaded/7c431ba03e837f904d10866cd436267f4ab12d74e76fbf464e3599cab5e61d06/src/Text/Email/Validate.hs
-:add .stack-work/downloaded/2e6a2889ab218635d549c10132bf8206e87b52831bb0b0d63119ff59a8407377/Mail/Hailgun.hs
-:set -XNoImplicitPrelude
+-- :set -XImplicitPrelude
+-- :add .stack-work/downloaded/7c431ba03e837f904d10866cd436267f4ab12d74e76fbf464e3599cab5e61d06/src/Text/Email/Validate.hs
+-- :add .stack-work/downloaded/2e6a2889ab218635d549c10132bf8206e87b52831bb0b0d63119ff59a8407377/Mail/Hailgun.hs
+-- :set -XNoImplicitPrelude
 -- :add src/Kucipong/Dev.hs
-:add src/Kucipong.hs
+-- :add src/Kucipong.hs
 -- import Kucipong.Dev

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dump-th:
 	@find "$$(stack path --dist-dir)" -name "*.dump-splices"
 
 ghci:
-	stack ghci --no-load
+	stack ghci
 
 haddock:
 	stack build --haddock

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -92,6 +92,7 @@ library
                      , MultiParamTypeClasses
                      , NoImplicitPrelude
                      , OverloadedStrings
+                     , PackageImports
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards
@@ -183,6 +184,18 @@ test-suite kucipong-test
                      , kucipong
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
+
+test-suite meetus-doctest
+  type:                exitcode-stdio-1.0
+  main-is:             DocTest.hs
+  hs-source-dirs:      test
+  build-depends:       base
+                     , classy-prelude
+                     , doctest
+                     , Glob
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  default-extensions:  NoImplicitPrelude
 
 source-repository head
   type:     git

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -41,11 +41,13 @@ library
                      , Kucipong.Monad.SendEmail.Trans
                      , Kucipong.Orphans
                      , Kucipong.Prelude
+                     , Kucipong.Session
                      , Kucipong.Util
   build-depends:       base >= 4.7 && < 5
                      , aeson
                      , base64-bytestring
                      , classy-prelude
+                     , clientsession
                      , emailaddress
                      , envelope
                      , hailgun

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -27,6 +27,7 @@ library
                      , Kucipong.Environment
                      , Kucipong.Errors
                      , Kucipong.Handler
+                     , Kucipong.Handler.Admin
                      , Kucipong.LoginToken
                      , Kucipong.Monad
                      , Kucipong.Monad.Db
@@ -51,6 +52,7 @@ library
                      , http-api-data
                      , http-client
                      , http-conduit
+                     , http-types
                      , lens
                      , monad-control
                      , monad-logger

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -57,6 +57,7 @@ library
                      , emailaddress
                      , envelope
                      , hailgun
+                     , HTTP
                      , http-api-data
                      , http-client
                      , http-conduit

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -46,6 +46,7 @@ library
                      , Kucipong.Orphans
                      , Kucipong.Prelude
                      , Kucipong.Session
+                     , Kucipong.Spock
                      , Kucipong.Util
   build-depends:       base >= 4.7 && < 5
                      , aeson

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -43,6 +43,7 @@ library
                      , Kucipong.Util
   build-depends:       base >= 4.7 && < 5
                      , aeson
+                     , base64-bytestring
                      , classy-prelude
                      , emailaddress
                      , envelope

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -28,6 +28,7 @@ library
                      , Kucipong.Errors
                      , Kucipong.Handler
                      , Kucipong.Handler.Admin
+                     , Kucipong.Host
                      , Kucipong.LoginToken
                      , Kucipong.Monad
                      , Kucipong.Monad.Cookie

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -30,6 +30,10 @@ library
                      , Kucipong.Handler.Admin
                      , Kucipong.LoginToken
                      , Kucipong.Monad
+                     , Kucipong.Monad.Cookie
+                     , Kucipong.Monad.Cookie.Class
+                     , Kucipong.Monad.Cookie.Instance
+                     , Kucipong.Monad.Cookie.Trans
                      , Kucipong.Monad.Db
                      , Kucipong.Monad.Db.Class
                      , Kucipong.Monad.Db.Instance

--- a/src/Kucipong/Email.hs
+++ b/src/Kucipong/Email.hs
@@ -8,7 +8,7 @@ import Mail.Hailgun
     ( HailgunContext, HailgunErrorMessage, HailgunErrorResponse(..)
     , HailgunMessage, HailgunSendResponse, MessageContent(..)
     , MessageRecipients(..), emptyMessageRecipients, hailgunMessage, sendEmail )
-import Text.Email.Validate ( toByteString )
+import "emailaddress" Text.Email.Validate ( toByteString )
 import Text.Shakespeare.Text ( st )
 
 import Kucipong.Errors ( AppErr, AppErrEnum(..), throwAppErr )

--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -5,7 +5,9 @@ import Kucipong.Prelude
 
 import Web.Spock ( Path, (<//>), get, html, root, runSpock, spockT, subcomponent, text, var )
 
-import Kucipong.Config ( Config, HasPort(..) )
+import Kucipong.Config ( Config )
+import Kucipong.Handler.Admin ( adminComponent )
+import Kucipong.Host ( HasPort(..) )
 import Kucipong.Monad ( KucipongM, runKucipongM )
 
 -- TODO: Remove this:
@@ -13,7 +15,6 @@ import Kucipong.Email
 import Mail.Hailgun
 import "emailaddress" Text.Email.Validate (emailAddress)
 
-import Kucipong.Handler.Admin ( adminComponent )
 
 helloR :: Path '[Text]
 helloR = "hello" <//> var

--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -11,7 +11,7 @@ import Kucipong.Monad ( KucipongM, runKucipongM )
 -- TODO: Remove this:
 import Kucipong.Email
 import Mail.Hailgun
-import Text.Email.Validate (emailAddress)
+import "emailaddress" Text.Email.Validate (emailAddress)
 
 import Kucipong.Handler.Admin ( adminComponent )
 

--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -3,7 +3,7 @@ module Kucipong.Handler where
 
 import Kucipong.Prelude
 
-import Web.Spock ( Path, (<//>), get, html, root, runSpock, spockT, text, var )
+import Web.Spock ( Path, (<//>), get, html, root, runSpock, spockT, subcomponent, text, var )
 
 import Kucipong.Config ( Config, HasPort(..) )
 import Kucipong.Monad ( KucipongM, runKucipongM )
@@ -12,6 +12,8 @@ import Kucipong.Monad ( KucipongM, runKucipongM )
 import Kucipong.Email
 import Mail.Hailgun
 import Text.Email.Validate (emailAddress)
+
+import Kucipong.Handler.Admin ( adminComponent )
 
 helloR :: Path '[Text]
 helloR = "hello" <//> var
@@ -25,6 +27,7 @@ runKucipongMHandleErrors config = either throwIO pure <=< runKucipongM config
 app :: Config -> IO ()
 app config = runSpock (getPort config) $
     spockT (runKucipongMHandleErrors config) $ do
+        subcomponent "admin" adminComponent
         get root $ do
             -- dbLoginUser undefined undefined
             html "<p>hello world</p>"

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -1,0 +1,59 @@
+
+module Kucipong.Handler.Admin where
+
+import Kucipong.Prelude
+
+import Control.Lens ( (^.) )
+import Control.Monad.Time ( MonadTime(..) )
+import Database.Persist ( Entity(..) )
+import Network.HTTP.Types ( forbidden403 )
+import Web.Spock
+    ( ActionCtxT, Path, SpockCtxT, (<//>), get, html, root, runSpock
+    , setStatus, spockT, text, var )
+
+import Kucipong.Db ( LoginTokenExpirationTime(..), adminLoginTokenExpirationTime )
+import Kucipong.LoginToken ( LoginToken )
+import Kucipong.Monad ( MonadKucipongDb(..), MonadKucipongSendEmail )
+import Kucipong.Util ( fromMaybeM )
+
+login
+    :: forall ctx m
+     . ( MonadIO m
+       , MonadKucipongDb m
+       , MonadTime m
+       )
+    => LoginToken -> ActionCtxT ctx m ()
+login loginToken = do
+    maybeAdminLoginTokenEntity <- dbFindAdminLoginToken loginToken
+    (Entity _ adminLoginToken) <-
+        fromMaybeM noAdminLoginTokenError maybeAdminLoginTokenEntity
+    -- check date on admin login token
+    now <- currentTime
+    let (LoginTokenExpirationTime expirationTime) =
+            adminLoginToken ^. adminLoginTokenExpirationTime
+    when (now > expirationTime) tokenExpiredError
+    -- TODO: Set the cookie.
+    html "<p>okay</p>"
+    -- TODO: Figure out what to actually return.  Also relevant below in the
+    -- error cases.
+  where
+    noAdminLoginTokenError :: ActionCtxT ctx m a
+    noAdminLoginTokenError = do
+        setStatus forbidden403
+        html "<p>loginToken incorrect</p>"
+
+    tokenExpiredError :: ActionCtxT ctx m a
+    tokenExpiredError = do
+        setStatus forbidden403
+        html "<p>token expired error</p>"
+
+adminComponent
+    :: forall m ctx
+     . ( MonadIO m
+       , MonadKucipongDb m
+       , MonadKucipongSendEmail m
+       , MonadTime m
+       )
+    => SpockCtxT ctx m ()
+adminComponent = do
+    get ("login" <//> var) login

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -16,6 +16,8 @@ import Kucipong.LoginToken ( LoginToken )
 import Kucipong.Monad ( MonadKucipongDb(..), MonadKucipongSendEmail )
 import Kucipong.Util ( fromMaybeM )
 
+-- | Login an admin.  Take the admin's 'LoginToken', and send them a session
+-- cookie.
 login
     :: forall ctx m
      . ( MonadIO m

--- a/src/Kucipong/Host.hs
+++ b/src/Kucipong/Host.hs
@@ -1,0 +1,34 @@
+
+module Kucipong.Host where
+
+import Kucipong.Prelude
+
+import Network.Wai.Handler.Warp ( Port )
+
+-- TODO: Pull this file out into a separate package.
+
+type Host = Text
+
+-- | Class for things that have a host.  For example, "localhost",
+-- "example.com", or "google.com:8080".
+class HasHost a where
+    getHost :: a -> Host
+
+mHost :: (HasHost r, MonadReader r m) => m Host
+mHost = reader getHost
+
+type Protocol = Text
+
+-- | Class for things that have a protocol.  For example, "http" or "https".
+class HasProtocol a where
+    getProtocol :: a -> Protocol
+
+mProtocol :: (HasProtocol r, MonadReader r m) => m Protocol
+mProtocol = reader getProtocol
+
+-- | Class for things that have a port.
+class HasPort a where
+    getPort :: a -> Port
+
+mPort :: (HasPort r, MonadReader r m) => m Port
+mPort = reader getPort

--- a/src/Kucipong/LoginToken.hs
+++ b/src/Kucipong/LoginToken.hs
@@ -4,6 +4,7 @@ module Kucipong.LoginToken where
 import Kucipong.Prelude
 
 import Control.Monad.Random ( MonadRandom, getRandoms )
+import Data.ByteString.Base64 ( encode )
 import Database.Persist ( PersistField(..) )
 import Database.Persist.Sql ( PersistFieldSql(..) )
 
@@ -11,4 +12,5 @@ newtype LoginToken = LoginToken { unLoginToken :: Text }
     deriving (Data, Eq, Generic, PersistField, PersistFieldSql, Show, Typeable)
 
 createRandomLoginToken :: MonadRandom m => m LoginToken
-createRandomLoginToken = LoginToken . pack . take 50 <$> getRandoms
+createRandomLoginToken =
+    LoginToken . decodeUtf8 . encode . pack . take 50 <$> getRandoms

--- a/src/Kucipong/LoginToken.hs
+++ b/src/Kucipong/LoginToken.hs
@@ -7,9 +7,10 @@ import Control.Monad.Random ( MonadRandom, getRandoms )
 import Data.ByteString.Base64 ( encode )
 import Database.Persist ( PersistField(..) )
 import Database.Persist.Sql ( PersistFieldSql(..) )
+import Web.PathPieces ( PathPiece )
 
 newtype LoginToken = LoginToken { unLoginToken :: Text }
-    deriving (Data, Eq, Generic, PersistField, PersistFieldSql, Show, Typeable)
+    deriving (Data, Eq, Generic, PathPiece, PersistField, PersistFieldSql, Show, Typeable)
 
 createRandomLoginToken :: MonadRandom m => m LoginToken
 createRandomLoginToken =

--- a/src/Kucipong/Monad/Cookie.hs
+++ b/src/Kucipong/Monad/Cookie.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Kucipong.Monad.Cookie ( module X ) where
+
+import Kucipong.Monad.Cookie.Class as X
+import Kucipong.Monad.Cookie.Instance as X ()
+import Kucipong.Monad.Cookie.Trans as X

--- a/src/Kucipong/Monad/Cookie/Class.hs
+++ b/src/Kucipong/Monad/Cookie/Class.hs
@@ -5,7 +5,7 @@ module Kucipong.Monad.Cookie.Class where
 import Kucipong.Prelude
 
 import Control.Monad.Trans ( MonadTrans )
-import Web.Spock ( ActionCtxT )
+import Web.Spock ( ActionCtxT, CookieSettings )
 
 import Kucipong.Monad.Db.Trans ( KucipongDbT )
 import Kucipong.Monad.SendEmail.Trans ( KucipongSendEmailT )
@@ -15,6 +15,17 @@ import Kucipong.Session ( Session )
 -- Default implementations are used to easily derive instances for monads
 -- transformers that implement 'MonadTrans'.
 class Monad m => MonadKucipongCookie m where
+    cookieSettings
+        :: m CookieSettings
+    default cookieSettings
+        :: ( Monad (t n)
+           , MonadKucipongCookie n
+           , MonadTrans t
+           , m ~ t n
+           )
+        => t n CookieSettings
+    cookieSettings = lift cookieSettings
+
     encryptSessionCookie
         :: Session sessionType
         -> m Text

--- a/src/Kucipong/Monad/Cookie/Class.hs
+++ b/src/Kucipong/Monad/Cookie/Class.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DefaultSignatures #-}
+
+module Kucipong.Monad.Cookie.Class where
+
+import Kucipong.Prelude
+
+import Control.Monad.Trans ( MonadTrans )
+import Web.Spock ( ActionCtxT )
+
+import Kucipong.Monad.Db.Trans ( KucipongDbT )
+import Kucipong.Monad.SendEmail.Trans ( KucipongSendEmailT )
+import Kucipong.Session ( Session )
+
+-- |
+-- Default implementations are used to easily derive instances for monads
+-- transformers that implement 'MonadTrans'.
+class Monad m => MonadKucipongCookie m where
+    encryptSessionCookie
+        :: Session sessionType
+        -> m Text
+    default encryptSessionCookie
+        :: ( Monad (t n)
+           , MonadKucipongCookie n
+           , MonadTrans t
+           , m ~ t n
+           )
+        => Session sessionType -> t n Text
+    encryptSessionCookie = lift . encryptSessionCookie
+
+instance MonadKucipongCookie m => MonadKucipongCookie (ActionCtxT ctx m)
+instance MonadKucipongCookie m => MonadKucipongCookie (ExceptT e m)
+instance MonadKucipongCookie m => MonadKucipongCookie (IdentityT m)
+instance MonadKucipongCookie m => MonadKucipongCookie (KucipongDbT m)
+instance MonadKucipongCookie m => MonadKucipongCookie (KucipongSendEmailT m)
+instance MonadKucipongCookie m => MonadKucipongCookie (ReaderT r m)

--- a/src/Kucipong/Monad/Cookie/Instance.hs
+++ b/src/Kucipong/Monad/Cookie/Instance.hs
@@ -5,15 +5,37 @@ module Kucipong.Monad.Cookie.Instance where
 
 import Kucipong.Prelude
 
+import Web.Spock
+    ( CookieSettings(..), CookieEOL(..), defaultCookieSettings )
+
+import Kucipong.Environment ( Environment(Production), HasEnv(getEnv) )
 import Kucipong.Monad.Cookie.Class ( MonadKucipongCookie(..) )
 import Kucipong.Monad.Cookie.Trans ( KucipongCookieT(..) )
 import Kucipong.Session ( HasSessionKey, Session, encryptSession )
+import Kucipong.Util ( oneYear )
 
 instance
-    ( HasSessionKey r
+    ( HasEnv r
+    , HasSessionKey r
     , MonadIO m
     , MonadReader r m
     ) => MonadKucipongCookie (KucipongCookieT m) where
+
+    cookieSettings :: KucipongCookieT m CookieSettings
+    cookieSettings = do
+        env <- reader getEnv
+        case env of
+            Production -> pure develCookieSettings { cs_secure = True }
+            _ -> pure develCookieSettings
+      where
+        develCookieSettings :: CookieSettings
+        develCookieSettings = defaultCookieSettings
+            { cs_EOL = CookieValidFor oneYear
+            , cs_HTTPOnly = True
+            , cs_secure = False
+            , cs_domain = Nothing
+            , cs_path = Just "/"
+            }
 
     encryptSessionCookie :: Session sessionType -> KucipongCookieT m Text
     encryptSessionCookie = lift . encryptSession

--- a/src/Kucipong/Monad/Cookie/Instance.hs
+++ b/src/Kucipong/Monad/Cookie/Instance.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Kucipong.Monad.Cookie.Instance where
+
+import Kucipong.Prelude
+
+import Kucipong.Monad.Cookie.Class ( MonadKucipongCookie(..) )
+import Kucipong.Monad.Cookie.Trans ( KucipongCookieT(..) )
+import Kucipong.Session ( HasSessionKey, Session, encryptSession )
+
+instance
+    ( HasSessionKey r
+    , MonadIO m
+    , MonadReader r m
+    ) => MonadKucipongCookie (KucipongCookieT m) where
+
+    encryptSessionCookie :: Session sessionType -> KucipongCookieT m Text
+    encryptSessionCookie = lift . encryptSession

--- a/src/Kucipong/Monad/Cookie/Trans.hs
+++ b/src/Kucipong/Monad/Cookie/Trans.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Kucipong.Monad.Cookie.Trans where
+
+import Kucipong.Prelude
+
+import Control.Monad.Random ( MonadRandom )
+import Control.Monad.Time ( MonadTime )
+import Control.Monad.Trans.Class ( MonadTrans )
+import Control.Monad.Trans.Control
+    ( ComposeSt, MonadBaseControl(..), MonadTransControl(..)
+    , defaultLiftBaseWith, defaultRestoreM )
+
+
+newtype KucipongCookieT m a = KucipongCookieT { unKucipongCookieT :: IdentityT m a }
+    deriving
+        ( Applicative
+        , Functor
+        , Monad
+        , MonadBase b
+        , MonadError e
+        , MonadIO
+        , MonadLogger
+        , MonadRandom
+        , MonadReader r
+        , MonadTime
+        , MonadTrans
+        )
+
+runKucipongCookieT :: KucipongCookieT m a -> m a
+runKucipongCookieT = runIdentityT . unKucipongCookieT
+
+instance MonadTransControl KucipongCookieT where
+    type StT KucipongCookieT a = a
+    liftWith f = lift (f runKucipongCookieT)
+    restoreT = KucipongCookieT . IdentityT
+    {-# INLINABLE liftWith #-}
+    {-# INLINABLE restoreT #-}
+
+instance (MonadBaseControl b m) => MonadBaseControl b (KucipongCookieT m) where
+    type StM (KucipongCookieT m) a = ComposeSt KucipongCookieT m a
+    liftBaseWith = defaultLiftBaseWith
+    restoreM     = defaultRestoreM
+    {-# INLINABLE liftBaseWith #-}
+    {-# INLINABLE restoreM #-}

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -53,6 +53,20 @@ class Monad m => MonadKucipongDb m where
         => LoginToken -> t n (Maybe (Entity AdminLoginToken))
     dbFindAdminLoginToken = lift . dbFindAdminLoginToken
 
+    dbUpsertAdmin
+        :: EmailAddress
+        -> Text
+        -- ^ Admin name
+        -> m (Entity Admin)
+    default dbUpsertAdmin
+        :: ( Monad (t n)
+           , MonadKucipongDb n
+           , MonadTrans t
+           , m ~ t n
+           )
+        => EmailAddress -> Text -> t n (Entity Admin)
+    dbUpsertAdmin = (lift .) . dbUpsertAdmin
+
 instance MonadKucipongDb m => MonadKucipongDb (ActionCtxT ctx m)
 instance MonadKucipongDb m => MonadKucipongDb (ExceptT e m)
 instance MonadKucipongDb m => MonadKucipongDb (IdentityT m)

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -10,6 +10,8 @@ import Web.Spock ( ActionCtxT )
 
 import Kucipong.Db ( Admin, AdminLoginToken, Key )
 import Kucipong.LoginToken ( LoginToken )
+import Kucipong.Monad.Cookie.Trans ( KucipongCookieT )
+import Kucipong.Monad.SendEmail.Trans ( KucipongSendEmailT )
 
 -- | Type-class for monads that can perform Db actions.  For instance, querying
 -- the database for information or writing new information to the database.
@@ -51,7 +53,9 @@ class Monad m => MonadKucipongDb m where
         => LoginToken -> t n (Maybe (Entity AdminLoginToken))
     dbFindAdminLoginToken = lift . dbFindAdminLoginToken
 
+instance MonadKucipongDb m => MonadKucipongDb (ActionCtxT ctx m)
 instance MonadKucipongDb m => MonadKucipongDb (ExceptT e m)
 instance MonadKucipongDb m => MonadKucipongDb (IdentityT m)
+instance MonadKucipongDb m => MonadKucipongDb (KucipongCookieT m)
+instance MonadKucipongDb m => MonadKucipongDb (KucipongSendEmailT m)
 instance MonadKucipongDb m => MonadKucipongDb (ReaderT r m)
-instance MonadKucipongDb m => MonadKucipongDb (ActionCtxT ctx m)

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -9,6 +9,7 @@ import Database.Persist ( Entity )
 import Web.Spock ( ActionCtxT )
 
 import Kucipong.Db ( Admin, AdminLoginToken, Key )
+import Kucipong.LoginToken ( LoginToken )
 
 -- | Type-class for monads that can perform Db actions.  For instance, querying
 -- the database for information or writing new information to the database.
@@ -39,6 +40,16 @@ class Monad m => MonadKucipongDb m where
            )
         => Key Admin -> t n (Entity AdminLoginToken)
     dbCreateAdminMagicLoginToken = lift . dbCreateAdminMagicLoginToken
+
+    dbFindAdminLoginToken :: LoginToken -> m (Maybe (Entity AdminLoginToken))
+    default dbFindAdminLoginToken
+        :: ( Monad (t n)
+           , MonadKucipongDb n
+           , MonadTrans t
+           , m ~ t n
+           )
+        => LoginToken -> t n (Maybe (Entity AdminLoginToken))
+    dbFindAdminLoginToken = lift . dbFindAdminLoginToken
 
 instance MonadKucipongDb m => MonadKucipongDb (ExceptT e m)
 instance MonadKucipongDb m => MonadKucipongDb (IdentityT m)

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -7,14 +7,14 @@ import Kucipong.Prelude
 
 import Control.Monad.Random ( MonadRandom(..) )
 import Control.Monad.Time ( MonadTime(..) )
-import Database.Persist ( Entity(..), insert, )
+import Database.Persist ( Entity(..), (==.), insert, selectFirst )
 
 import Kucipong.Config ( Config )
 import Kucipong.Db
-    ( Admin(..), AdminLoginToken(..), CreatedTime(..), Key
+    ( Admin(..), AdminLoginToken(..), CreatedTime(..), EntityField(..), Key
     , LoginTokenExpirationTime(..), UpdatedTime(..), runDb )
 import Kucipong.Errors ( AppErr )
-import Kucipong.LoginToken ( createRandomLoginToken )
+import Kucipong.LoginToken ( LoginToken, createRandomLoginToken )
 import Kucipong.Monad.Db.Class ( MonadKucipongDb(..) )
 import Kucipong.Monad.Db.Trans ( KucipongDbT(..) )
 import Kucipong.Util ( addOneDay )
@@ -53,3 +53,9 @@ instance ( MonadBaseControl IO m
                         (LoginTokenExpirationTime plusOneDay)
             adminLoginTokenKey <- runDb $ insert adminLoginToken
             pure $ Entity adminLoginTokenKey adminLoginToken
+
+    dbFindAdminLoginToken :: LoginToken -> KucipongDbT m (Maybe (Entity AdminLoginToken))
+    dbFindAdminLoginToken loginToken = lift go
+      where
+        go :: m (Maybe (Entity AdminLoginToken))
+        go = runDb $ selectFirst [AdminLoginTokenLoginToken ==. loginToken] []

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -50,12 +50,12 @@ instance ( MonadBaseControl IO m
             currTime <- currentTime
             randomLoginToken <- createRandomLoginToken
             let plusOneDay = addOneDay currTime
-            let adminLoginToken =
+            let newAdminLoginTokenVal =
                     AdminLoginToken adminKey (CreatedTime currTime)
                         (UpdatedTime currTime) Nothing randomLoginToken
                         (LoginTokenExpirationTime plusOneDay)
-            adminLoginTokenKey <- runDb $ insert adminLoginToken
-            pure $ Entity adminLoginTokenKey adminLoginToken
+            runDb $ repsert (AdminLoginTokenKey adminKey) newAdminLoginTokenVal
+            pure $ Entity (AdminLoginTokenKey adminKey) newAdminLoginTokenVal
 
     dbFindAdminLoginToken :: LoginToken -> KucipongDbT m (Maybe (Entity AdminLoginToken))
     dbFindAdminLoginToken loginToken = lift go

--- a/src/Kucipong/Monad/SendEmail/Class.hs
+++ b/src/Kucipong/Monad/SendEmail/Class.hs
@@ -8,6 +8,7 @@ import Control.Monad.Trans ( MonadTrans )
 import Web.Spock ( ActionCtxT )
 
 import Kucipong.LoginToken ( LoginToken )
+import Kucipong.Monad.Cookie.Trans ( KucipongCookieT )
 import Kucipong.Monad.Db.Trans ( KucipongDbT )
 
 -- |
@@ -27,8 +28,9 @@ class Monad m => MonadKucipongSendEmail m where
         => EmailAddress -> LoginToken -> t n ()
     sendAdminLoginEmail = (lift .) . sendAdminLoginEmail
 
+instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ActionCtxT ctx m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ExceptT e m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (IdentityT m)
+instance MonadKucipongSendEmail m => MonadKucipongSendEmail (KucipongCookieT m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (KucipongDbT m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ReaderT r m)
-instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ActionCtxT ctx m)

--- a/src/Kucipong/Monad/SendEmail/Instance.hs
+++ b/src/Kucipong/Monad/SendEmail/Instance.hs
@@ -8,12 +8,15 @@ import Kucipong.Prelude
 import Kucipong.Email ( HasHailgunContext )
 import qualified Kucipong.Email as Email
 import Kucipong.Errors ( AppErr )
+import Kucipong.Host ( HasHost, HasProtocol )
 import Kucipong.LoginToken ( LoginToken )
 import Kucipong.Monad.SendEmail.Class ( MonadKucipongSendEmail(..) )
 import Kucipong.Monad.SendEmail.Trans ( KucipongSendEmailT(..) )
 
 instance
     ( HasHailgunContext r
+    , HasHost r
+    , HasProtocol r
     , MonadError AppErr m
     , MonadIO m
     , MonadReader r m

--- a/src/Kucipong/Prelude.hs
+++ b/src/Kucipong/Prelude.hs
@@ -12,6 +12,6 @@ import Control.Monad.Trans.Identity as X ( IdentityT(..), runIdentityT )
 import Data.Data as X ( Data )
 import Data.Proxy as X ( Proxy(Proxy) )
 import Data.Word as X ( Word16 )
-import Text.Email.Validate as X ( EmailAddress )
+import "emailaddress" Text.Email.Validate as X ( EmailAddress )
 
 import Kucipong.Orphans as X ()

--- a/src/Kucipong/Session.hs
+++ b/src/Kucipong/Session.hs
@@ -1,0 +1,39 @@
+
+module Kucipong.Session
+    ( -- * Session type
+      Session(..)
+      -- * Markers for either AdminSession or StoreSession
+    , Admin
+    , Store
+      -- * Classes and functions dealing with Session Key
+    , HasSessionKey(..)
+    )
+    where
+
+import Kucipong.Prelude
+
+import Web.ClientSession ( Key )
+
+class HasSessionKey r where
+    getSessionKey :: r -> Key
+
+instance HasSessionKey Key where
+    getSessionKey :: Key -> Key
+    getSessionKey = id
+
+-- | Raw session data.  This is used by 'AdminSession' and 'StoreSession'.
+newtype RawSession = RawSession { unRawSession :: Text }
+    deriving (Data, Eq, Generic, Show, Typeable)
+
+-- | Tag for 'AdminSession'
+data Admin
+
+-- | Tag for 'StoreSession'.
+data Store
+
+data Session :: * -> * where
+    AdminSession :: RawSession -> Session Admin
+    StoreSession :: RawSession -> Session Store
+
+createRawSession :: MonadIO m => m RawSession
+createRawSession = undefined

--- a/src/Kucipong/Spock.hs
+++ b/src/Kucipong/Spock.hs
@@ -1,0 +1,33 @@
+
+module Kucipong.Spock where
+
+import Kucipong.Prelude
+
+import Web.Spock ( ActionCtxT, setCookie )
+
+import Kucipong.Monad ( MonadKucipongCookie(cookieSettings, encryptSessionCookie) )
+import Kucipong.Session ( Session(AdminSession, StoreSession) )
+
+setAdminCookie
+    :: ( MonadIO m
+       , MonadKucipongCookie m
+       )
+    => EmailAddress -> ActionCtxT ctx m ()
+setAdminCookie = setCookieGeneric "adminEmail" . AdminSession
+
+setStoreCookie
+    :: ( MonadIO m
+       , MonadKucipongCookie m
+       )
+    => EmailAddress -> ActionCtxT ctx m ()
+setStoreCookie = setCookieGeneric "storeEmail" . StoreSession
+
+setCookieGeneric
+    :: ( MonadIO m
+       , MonadKucipongCookie m
+       )
+    => Text -> Session sessionType -> ActionCtxT ctx m ()
+setCookieGeneric cookieKey sessionVal = do
+    cookieVal <- encryptSessionCookie sessionVal
+    settings <- cookieSettings
+    setCookie cookieKey cookieVal settings

--- a/src/Kucipong/Util.hs
+++ b/src/Kucipong/Util.hs
@@ -14,6 +14,16 @@ import Data.Time.Clock ( NominalDiffTime, addUTCTime )
 
 infixr 8 <$$>
 
+-- | Similar to 'fromMaybe'.  @'fromMaybeM' action@ is the same as @'maybe'
+-- action 'pure'@.
+--
+-- >>> fromMaybeM (putStrLn "hello") Nothing
+-- hello
+-- >>> fromMaybeM (Left "there was an error") (Just 3)
+-- Right 3
+fromMaybeM :: Applicative m => m a -> Maybe a -> m a
+fromMaybeM action = maybe action pure
+
 oneDay :: NominalDiffTime
 oneDay = 60 * 60 * 24
 

--- a/src/Kucipong/Util.hs
+++ b/src/Kucipong/Util.hs
@@ -24,6 +24,16 @@ infixr 8 <$$>
 fromMaybeM :: Applicative m => m a -> Maybe a -> m a
 fromMaybeM action = maybe action pure
 
+-- | Similar to 'fromMaybeM'.  @'fromEitherM' errHandler@ is the same as
+-- @'either' errHandler 'pure'@.
+--
+-- >>> fromEitherM (putStrLn) $ Left "hello"
+-- hello
+-- >>> fromEitherM (const Nothing) (Right 3)
+-- Just 3
+fromEitherM :: Applicative m => (e -> m a) -> Either e a -> m a
+fromEitherM errHandler = either errHandler pure
+
 oneDay :: NominalDiffTime
 oneDay = 60 * 60 * 24
 

--- a/src/Kucipong/Util.hs
+++ b/src/Kucipong/Util.hs
@@ -27,6 +27,9 @@ fromMaybeM action = maybe action pure
 oneDay :: NominalDiffTime
 oneDay = 60 * 60 * 24
 
+oneYear :: NominalDiffTime
+oneYear = oneDay * 365
+
 -- | Add one day to a 'UTCTime'.
 addOneDay :: UTCTime -> UTCTime
 addOneDay = addUTCTime oneDay

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,27 +7,14 @@ resolver: lts-6.13
 # Local packages, usually specified by relative directory name
 packages:
     - '.'
-    # TODO: This was added here: https://github.com/fpco/stackage/pull/1782
-    # Hopefull we'll be able to use it when lts-6.14 comes out.  It should be
-    # out sometime around 2016/09/01.
-    - location:
-        git: 'https://bitbucket.org/cdepillabout/hailgun'
-        commit: '275a4ebdeab79f7fb048e6174ca2f2bf75aa1f71' # derive-show branch
-    # TODO: This will probably be in stackage lts-6.14.  It can get removed
-    # then.  Also, it can get pushed down to the "extra-deps" section sometime
-    # after 8/23.  It can't be done immediately because stack's hackage
-    # databases only update every 24 hours.
-    - location:
-        git: 'https://github.com/cdepillabout/emailaddress'
-        commit: v0.1.6.0
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
-    # This will probably be in lts-6.14.
-    # - emailaddress-0.1.6.0
-    # This will probably be available sometime after 8/22 in hackage, and in
-    # lts-6.14.
-    # - hailgun-0.4.1.0
+extra-deps:
+    # This might not be available until the next major lts release.
+    - emailaddress-0.1.6.0
+    # This will probably be available at least by 9/15 in hackage, and in
+    # lts-6.15. (Or it might not be available until the next major lts release.)
+    - hailgun-0.4.1.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -1,0 +1,41 @@
+
+module Main (main) where
+
+import ClassyPrelude
+
+import System.FilePath.Glob (glob)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = glob "src/**/*.hs" >>= doDocTest
+
+doDocTest :: [String] -> IO ()
+doDocTest options = doctest $ options <> ghcExtensions
+
+ghcExtensions :: [String]
+ghcExtensions =
+    [ "-XConstraintKinds"
+    , "-XDataKinds"
+    , "-XDeriveDataTypeable"
+    , "-XDeriveFunctor"
+    , "-XDeriveGeneric"
+    , "-XEmptyDataDecls"
+    , "-XFlexibleContexts"
+    , "-XFlexibleInstances"
+    , "-XGADTs"
+    , "-XGeneralizedNewtypeDeriving"
+    , "-XInstanceSigs"
+    , "-XMultiParamTypeClasses"
+    , "-XNamedFieldPuns"
+    , "-XNoImplicitPrelude"
+    , "-XOverloadedStrings"
+    , "-XPackageImports"
+    , "-XPolyKinds"
+    , "-XRankNTypes"
+    , "-XRecordWildCards"
+    , "-XScopedTypeVariables"
+    , "-XStandaloneDeriving"
+    , "-XTupleSections"
+    , "-XTypeFamilies"
+    , "-XTypeOperators"
+    ]


### PR DESCRIPTION
This PR allows an admin user to actually login.

When an admin user is created with the following command:

``` bash
$ stack exec -- kucipong-add-admin kucipong.dev@gmail.com "test name"
```

They are sent an email with a url they can use to login.  

The login handler is `Kucipong.Handler.Admin.login`.  It sets an encrypted session cookie with the admin's email address.

This code currently doesn't redirect the admin user to the homepage.  That will be implemented in a future PR.

@arowM @kayhide Please review.
