### PR TITLE
Template haskell ede

### DIFF
--- a/.hindent.yaml
+++ b/.hindent.yaml
@@ -1,0 +1,4 @@
+# We use 4 space indents.
+indent-size: 4
+line-length: 80
+force-trailing-newline: false

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -46,6 +46,7 @@ library
                      , Kucipong.Monad.SendEmail.Trans
                      , Kucipong.Orphans
                      , Kucipong.Prelude
+                     , Kucipong.RenderTemplate
                      , Kucipong.Session
                      , Kucipong.Spock
                      , Kucipong.Util
@@ -80,6 +81,7 @@ library
                      , resource-pool
                      , shakespeare
                      , Spock
+                     , template-haskell
                      , time
                      , transformers
                      , transformers-base

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -82,6 +82,7 @@ library
                      , shakespeare
                      , Spock
                      , template-haskell
+                     , th-lift-instances
                      , time
                      , transformers
                      , transformers-base

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -90,7 +90,8 @@ library
                      , warp
   default-language:    Haskell2010
   ghc-options:         -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction
-  default-extensions:  ConstraintKinds
+  default-extensions:  BangPatterns
+                     , ConstraintKinds
                      , DataKinds
                      , DefaultSignatures
                      , DeriveDataTypeable
@@ -124,7 +125,8 @@ executable kucipong
   build-depends:       base
                      , kucipong
   default-language:    Haskell2010
-  default-extensions:  ConstraintKinds
+  default-extensions:  BangPatterns
+                     , ConstraintKinds
                      , DataKinds
                      , DefaultSignatures
                      , DeriveDataTypeable
@@ -162,7 +164,8 @@ executable kucipong-add-admin
                      , optparse-applicative
                      , persistent
   default-language:    Haskell2010
-  default-extensions:  ConstraintKinds
+  default-extensions:  BangPatterns
+                     , ConstraintKinds
                      , DataKinds
                      , DefaultSignatures
                      , DeriveDataTypeable

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -54,6 +54,7 @@ library
                      , base64-bytestring
                      , classy-prelude
                      , clientsession
+                     , ede
                      , emailaddress
                      , envelope
                      , hailgun

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -70,21 +70,8 @@ storeCreate
     => ActionCtxT (HVect xs) m ()
 storeCreate = do
     (AdminSession email) <- getAdminEmail
-    -- TODO: Actually return the correct html from here.
-    let rawTemplate = "{% if var %}\nHello, {{ var }}!\n{% else %}\nnegative!\n{% endif %}\n"
-        env = fromPairs [ "var1" .= ("World" :: Text) ]
-        eitherParsedTemplate = eitherParse rawTemplate
-    template <- fromEitherM
-        (html . ("err occured when parsing template: " <>) . pack)
-        eitherParsedTemplate
-    let eitherRenderedTemplate = eitherRender template env
-    renderedTemplate <- fromEitherM
-        (html . ("err occured when trying to render template: " <>) . pack)
-        eitherRenderedTemplate
-    let lala = $(renderTemplateFromEnv "adminUser_admin_store_create.html")
-    $(logDebug) $ lala
-    html . toStrict $ "rendered template: " <> renderedTemplate
-    -- $(renderTemplateFromEnv "adminUser_admin_store_create.html")
+    $(renderTemplateFromEnv "adminUser_admin_store_create.html") $ fromPairs
+        [ "adminEmail" .= email ]
 
 adminAuthHook
     :: ( MonadIO m

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 
 module Kucipong.Handler.Admin where
 
@@ -63,6 +64,7 @@ storeCreate
     :: forall xs n m
      . ( ContainsAdminSession n xs
        , MonadIO m
+       , MonadLogger m
        )
     => ActionCtxT (HVect xs) m ()
 storeCreate = do
@@ -102,6 +104,7 @@ adminComponent
        , MonadKucipongCookie m
        , MonadKucipongDb m
        , MonadKucipongSendEmail m
+       , MonadLogger m
        , MonadTime m
        )
     => SpockCtxT (HVect xs) m ()

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -21,6 +21,7 @@ import Kucipong.Db
 import Kucipong.LoginToken ( LoginToken )
 import Kucipong.Monad
     ( MonadKucipongCookie, MonadKucipongDb(..), MonadKucipongSendEmail )
+import Kucipong.RenderTemplate ( renderTemplateFromEnv )
 import Kucipong.Spock
     ( ContainsAdminSession, getAdminCookie, getAdminEmail, setAdminCookie )
 import Kucipong.Session ( Admin, Session(..) )
@@ -70,7 +71,7 @@ storeCreate
 storeCreate = do
     (AdminSession email) <- getAdminEmail
     -- TODO: Actually return the correct html from here.
-    let rawTemplate = "{{ hello }}{% if var %}\nHello, {{ var }}!\n{% else %}\nnegative!\n{% endif %}\n"
+    let rawTemplate = "{% if var %}\nHello, {{ var }}!\n{% else %}\nnegative!\n{% endif %}\n"
         env = fromPairs [ "var1" .= ("World" :: Text) ]
         eitherParsedTemplate = eitherParse rawTemplate
     template <- fromEitherM
@@ -80,6 +81,8 @@ storeCreate = do
     renderedTemplate <- fromEitherM
         (html . ("err occured when trying to render template: " <>) . pack)
         eitherRenderedTemplate
+    let lala = $(renderTemplateFromEnv "adminUser_admin_store_create.html")
+    $(logDebug) $ lala
     html . toStrict $ "rendered template: " <> renderedTemplate
     -- $(renderTemplateFromEnv "adminUser_admin_store_create.html")
 

--- a/src/Kucipong/Monad/OtherInstances.hs
+++ b/src/Kucipong/Monad/OtherInstances.hs
@@ -5,10 +5,13 @@ module Kucipong.Monad.OtherInstances where
 import Kucipong.Prelude
 
 import Control.Monad.Random ( MonadRandom(..) )
+import Web.Spock ( ActionCtxT )
 
 instance MonadRandom m => MonadRandom (LoggingT m) where
     getRandom = lift getRandom
     getRandomR = lift . getRandomR
     getRandoms = lift getRandoms
     getRandomRs = lift . getRandomRs
+
+instance MonadLogger m => MonadLogger (ActionCtxT ctx m)
 

--- a/src/Kucipong/Monad/OtherInstances.hs
+++ b/src/Kucipong/Monad/OtherInstances.hs
@@ -1,17 +1,3 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Kucipong.Monad.OtherInstances where
-
-import Kucipong.Prelude
-
-import Control.Monad.Random ( MonadRandom(..) )
-import Web.Spock ( ActionCtxT )
-
-instance MonadRandom m => MonadRandom (LoggingT m) where
-    getRandom = lift getRandom
-    getRandomR = lift . getRandomR
-    getRandoms = lift getRandoms
-    getRandomRs = lift . getRandomRs
-
-instance MonadLogger m => MonadLogger (ActionCtxT ctx m)
-

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -10,3 +10,22 @@ other libraries but that we use here.
 -}
 
 module Kucipong.Orphans where
+
+import ClassyPrelude
+
+import Control.Monad.Logger ( LoggingT, MonadLogger )
+import Control.Monad.Random ( MonadRandom(..) )
+import Language.Haskell.TH ( Q, runIO )
+import Web.Spock ( ActionCtxT )
+
+instance MonadRandom m => MonadRandom (LoggingT m) where
+    getRandom = lift getRandom
+    getRandomR = lift . getRandomR
+    getRandoms = lift getRandoms
+    getRandomRs = lift . getRandomRs
+
+instance MonadLogger m => MonadLogger (ActionCtxT ctx m)
+
+instance MonadIO Q where
+    liftIO :: IO a -> Q a
+    liftIO = runIO

--- a/src/Kucipong/Prelude.hs
+++ b/src/Kucipong/Prelude.hs
@@ -5,7 +5,7 @@ import ClassyPrelude as X
 
 import Control.Monad.Base as X ( MonadBase(..) )
 import Control.Monad.Except as X ( ExceptT(..), MonadError(..), runExceptT )
-import Control.Monad.Logger as X ( LoggingT, MonadLogger )
+import Control.Monad.Logger as X ( LoggingT, MonadLogger, logDebug )
 import Control.Monad.Reader as X ( reader )
 import Control.Monad.Trans.Control as X ( MonadBaseControl )
 import Control.Monad.Trans.Identity as X ( IdentityT(..), runIdentityT )

--- a/src/Kucipong/Prelude.hs
+++ b/src/Kucipong/Prelude.hs
@@ -14,4 +14,7 @@ import Data.Proxy as X ( Proxy(Proxy) )
 import Data.Word as X ( Word16 )
 import "emailaddress" Text.Email.Validate as X ( EmailAddress )
 
+-- Orphan instances
+
 import Kucipong.Orphans as X ()
+import Instances.TH.Lift as X ()

--- a/src/Kucipong/RenderTemplate.hs
+++ b/src/Kucipong/RenderTemplate.hs
@@ -1,10 +1,37 @@
 
 module Kucipong.RenderTemplate where
 
-import Kucipong.Prelude
+import Kucipong.Prelude hiding ( try )
 
+import Control.Exception ( try )
 import Language.Haskell.TH ( Exp, Q, litE, stringL )
+import Text.EDE ( eitherParse, eitherRender, fromPairs )
+
+import Kucipong.Util ( fromEitherM )
+
+templateDirectory :: FilePath
+templateDirectory = "frontend" </> "dist"
 
 renderTemplateFromEnv :: String -> Q Exp
 renderTemplateFromEnv filename = do
+    eitherRawTemplate <- liftIO . try $ readFile fullFilePath
+    rawTemplate <- fromEitherM handleTemplateFileRead eitherRawTemplate
+    let eitherParsedTemplate = eitherParse rawTemplate
+    -- Check to make sure the template can be parsed correctly.  Return an
+    -- error to the user if it cannot.
+    void $ fromEitherM handleIncorrectTemplate eitherParsedTemplate
     litE $ stringL "hello"
+  where
+    -- This is the full path of the template file.
+    fullFilePath :: FilePath
+    fullFilePath = templateDirectory </> filename
+
+    handleTemplateFileRead :: SomeException -> Q a
+    handleTemplateFileRead exception = fail $
+        "exception occured when trying to read file \"" <>
+        fullFilePath <>
+        ": " <>
+        show exception
+
+    handleIncorrectTemplate :: String -> Q a
+    handleIncorrectTemplate errorMsg = undefined

--- a/src/Kucipong/RenderTemplate.hs
+++ b/src/Kucipong/RenderTemplate.hs
@@ -1,0 +1,10 @@
+
+module Kucipong.RenderTemplate where
+
+import Kucipong.Prelude
+
+import Language.Haskell.TH ( Exp, Q, litE, stringL )
+
+renderTemplateFromEnv :: String -> Q Exp
+renderTemplateFromEnv filename = do
+    litE $ stringL "hello"

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -14,7 +14,8 @@ doDocTest options = doctest $ options <> ghcExtensions
 
 ghcExtensions :: [String]
 ghcExtensions =
-    [ "-XConstraintKinds"
+    [ "-XBangPatterns"
+    , "-XConstraintKinds"
     , "-XDataKinds"
     , "-XDeriveDataTypeable"
     , "-XDeriveFunctor"


### PR DESCRIPTION
I have a rough version of #6 working.

It's currently not type-safe with respect to template parameters, but it does make sure the template parses correctly at compile time.

I don't think it's possible to take the template parameters from the environment, because it's impossible to see what variables nd types the template will need.

(For instance, with a template like `{% if var %} {{ foo }} {% else %} {{ bar }} {% endif %}`, it's impossible to know whether the template will need `foo` or `bar` without first trying to render it.)

Maybe if we used a different template library we could get something that is more type-safe.

Also, #6 needs to be merged in before this can be merged in.

@arowM Please take a look at this, especially commit c822470.  What do you think?
