### PR TITLE
Redirect to the admin login page on failed admin login attempt.

### DIFF
--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -9,7 +9,7 @@ import Web.Spock
     , text, var )
 
 import Kucipong.Config ( Config )
-import Kucipong.Handler.Admin ( adminComponent )
+import Kucipong.Handler.Admin ( adminComponent, adminUrlPrefix )
 import Kucipong.Host ( HasPort(..) )
 import Kucipong.Monad ( KucipongM, runKucipongM )
 
@@ -35,7 +35,7 @@ app :: Config -> IO ()
 app config = runSpock (getPort config) $
     spockT (runKucipongMHandleErrors config) $ do
         prehook baseHook $
-            subcomponent "admin" adminComponent
+            subcomponent adminUrlPrefix adminComponent
         get root $ do
             -- dbLoginUser undefined undefined
             html "<p>hello world</p>"


### PR DESCRIPTION
The admin login page was added in #8, so this PR is making use of that page.

This is the functionality that was requested in #8.

@arowM Please review.
