### PR TITLE
Admin store create

### DIFF
--- a/app/AddAdmin.hs
+++ b/app/AddAdmin.hs
@@ -23,13 +23,11 @@ data AddAdminCommand = AddAdminCommand
     }
     deriving (Data, Eq, Generic, Show, Typeable)
 
-tryExceptT :: (MonadBaseControl IO m, Exception e) => m a -> ExceptT e m a
-tryExceptT = ExceptT . try
-
 -- | Add a new 'Admin'.  If an 'Admin' with the 'EmailAddress' already exists,
 -- just create a new 'AdminLoginToken' for them and then send them an email.
 addAdmin
     :: ( MonadBaseControl IO m
+       , MonadCatch m
        , MonadIO m
        , MonadKucipongDb m
        , MonadKucipongSendEmail m

--- a/app/AddAdmin.hs
+++ b/app/AddAdmin.hs
@@ -3,6 +3,7 @@ module Main where
 
 import Kucipong.Prelude
 
+import Control.FromSum ( fromEitherM )
 import Control.Lens ( view )
 import Database.Persist ( Entity(..) )
 import Options.Applicative
@@ -15,7 +16,6 @@ import Kucipong.Config ( createConfigFromEnv )
 import Kucipong.Db ( adminLoginTokenLoginToken )
 import Kucipong.Monad
     ( MonadKucipongDb(..), MonadKucipongSendEmail(..), runKucipongM )
-import Kucipong.Util ( fromEitherM )
 
 data AddAdminCommand = AddAdminCommand
     { addAdminEmail :: EmailAddress

--- a/app/AddAdmin.hs
+++ b/app/AddAdmin.hs
@@ -4,7 +4,6 @@ module Main where
 import Kucipong.Prelude
 
 import Control.FromSum ( fromEitherM )
-import Control.Lens ( view )
 import Database.Persist ( Entity(..) )
 import Options.Applicative
     ( InfoMod, Parser, ParserInfo, ReadM, argument, eitherReader, execParser
@@ -42,7 +41,7 @@ addAdmin email name = do
     eitherAdminLoginToken <- try $ dbCreateAdminMagicLoginToken adminKey
     (Entity _ adminLoginToken) <-
         fromEitherM handleCreateAdminLoginTokenError eitherAdminLoginToken
-    let loginToken = view adminLoginTokenLoginToken adminLoginToken
+    let loginToken = adminLoginTokenLoginToken adminLoginToken
     sendAdminLoginEmail email loginToken
     putStrLn $ "Created (or updated) admin with email " <> tshow email <>
         " and name \"" <> name <> "\".\nSent email with login url."

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -26,6 +26,7 @@ library
                      , Kucipong.Email
                      , Kucipong.Environment
                      , Kucipong.Errors
+                     , Kucipong.Form
                      , Kucipong.Handler
                      , Kucipong.Handler.Admin
                      , Kucipong.Handler.Store
@@ -51,6 +52,7 @@ library
                      , Kucipong.RenderTemplate
                      , Kucipong.Session
                      , Kucipong.Spock
+                     , Kucipong.Spock.ReqParam
                      , Kucipong.Util
   build-depends:       base >= 4.7 && < 5
                      , aeson
@@ -60,6 +62,7 @@ library
                      , ede
                      , emailaddress
                      , envelope
+                     , from-sum
                      , hailgun
                      , HTTP
                      , http-api-data

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -83,9 +83,11 @@ library
                      , postgresql-simple
                      , pwstore-fast
                      , read-env-var
+                     , reroute
                      , resource-pool
                      , shakespeare
                      , Spock
+                     , Spock-core
                      , template-haskell
                      , th-lift-instances
                      , time
@@ -111,6 +113,7 @@ library
                      , InstanceSigs
                      , MultiParamTypeClasses
                      , NoImplicitPrelude
+                     , NoMonomorphismRestriction
                      , OverloadedStrings
                      , PackageImports
                      , PolyKinds
@@ -146,6 +149,7 @@ executable kucipong
                      , InstanceSigs
                      , MultiParamTypeClasses
                      , NoImplicitPrelude
+                     , NoMonomorphismRestriction
                      , OverloadedStrings
                      , PolyKinds
                      , RankNTypes
@@ -186,6 +190,7 @@ executable kucipong-add-admin
                      , MultiParamTypeClasses
                      , NamedFieldPuns
                      , NoImplicitPrelude
+                     , NoMonomorphismRestriction
                      , OverloadedStrings
                      , PolyKinds
                      , RankNTypes

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -169,6 +169,7 @@ executable kucipong-add-admin
   build-depends:       base
                      , kucipong
                      , emailaddress
+                     , from-sum
                      , lens
                      , monad-time
                      , optparse-applicative

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -28,6 +28,7 @@ library
                      , Kucipong.Errors
                      , Kucipong.Handler
                      , Kucipong.Handler.Admin
+                     , Kucipong.Handler.Store
                      , Kucipong.Host
                      , Kucipong.LoginToken
                      , Kucipong.Monad
@@ -45,6 +46,7 @@ library
                      , Kucipong.Monad.SendEmail.Instance
                      , Kucipong.Monad.SendEmail.Trans
                      , Kucipong.Orphans
+                     , Kucipong.Persist
                      , Kucipong.Prelude
                      , Kucipong.RenderTemplate
                      , Kucipong.Session

--- a/src/Kucipong/Config.hs
+++ b/src/Kucipong/Config.hs
@@ -5,6 +5,7 @@ module Kucipong.Config
 
 import Kucipong.Prelude
 
+import Control.FromSum ( fromEitherM )
 import Control.Monad.Logger ( runStdoutLoggingT )
 import Data.ByteString.Base64 ( decode )
 import Database.Persist.Postgresql ( ConnectionPool )
@@ -26,7 +27,6 @@ import Kucipong.Email ( HasHailgunContext(..) )
 import Kucipong.Host
     ( HasHost(..), HasPort(..), HasProtocol(..), Host, Protocol )
 import Kucipong.Session ( HasSessionKey(..) )
-import Kucipong.Util ( fromEitherM )
 
 -- | A 'Config' used by our application.  It contains things used
 -- throughout a request.

--- a/src/Kucipong/Db/Models.hs
+++ b/src/Kucipong/Db/Models.hs
@@ -24,7 +24,7 @@ import Kucipong.Db.Models.Base
 import Kucipong.Db.Models.EntityDefs ( kucipongEntityDefs )
 import Kucipong.LoginToken ( LoginToken )
 
-share [ mkPersist sqlSettings { mpsGenerateLenses = True }
+share [ mkPersist sqlSettings { mpsGenerateLenses = False }
       , mkMigrate "migrateAll"
       ]
       kucipongEntityDefs

--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -42,13 +42,13 @@ kucipongEntityDefs = [persistLowerCase|
         deriving Typeable
 
     Store
-        email                   EmailAddress
+        storeEmail              StoreEmailId
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe
         name                    Text
-        businessCategory        Text Maybe
-        businessCategoryDetail  Text Maybe
+        businessCategory        Text
+        businessCategoryDetail  Text
         image                   Image Maybe
         salesPoint              Text Maybe
         address                 Text Maybe
@@ -57,6 +57,18 @@ kucipongEntityDefs = [persistLowerCase|
         regularHoliday          Text Maybe
         url                     Text Maybe
 
+        Primary storeEmail
+
+        deriving Eq
+        deriving Show
+        deriving Typeable
+
+    StoreEmail
+        email                   EmailAddress
+        created                 CreatedTime
+        updated                 UpdatedTime
+        deleted                 DeletedTime Maybe
+
         Primary email
 
         deriving Eq
@@ -64,7 +76,7 @@ kucipongEntityDefs = [persistLowerCase|
         deriving Typeable
 
     StoreLoginToken
-        email                   StoreId
+        email                   StoreEmailId
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe

--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -41,11 +41,21 @@ kucipongEntityDefs = [persistLowerCase|
         deriving Show
         deriving Typeable
 
-    CompanyEmail
+    Store
         email                   EmailAddress
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe
+        name                    Text
+        businessCategory        Text Maybe
+        businessCategoryDetail  Text Maybe
+        image                   Image Maybe
+        salesPoint              Text Maybe
+        address                 Text Maybe
+        phoneNumber             Text Maybe
+        businessHours           Text Maybe
+        regularHoliday          Text Maybe
+        url                     Text Maybe
 
         Primary email
 
@@ -53,21 +63,15 @@ kucipongEntityDefs = [persistLowerCase|
         deriving Show
         deriving Typeable
 
-    Company
+    StoreLoginToken
+        email                   StoreId
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe
-        emailAddr               CompanyEmailId
-        name                    Text
-        businessCategory        Text
-        businessCategoryDetail  Text
-        image                   Image
-        salesPoint              Text
-        address                 Text
-        phoneNumber             Text
-        businessHours           Text
-        regularHoliday          Text
-        url                     Text
+        loginToken              LoginToken
+        expirationTime          LoginTokenExpirationTime
+
+        Primary email
 
         deriving Eq
         deriving Show

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -9,5 +9,11 @@ module Kucipong.Form where
 
 import Kucipong.Prelude
 
+import Web.FormUrlEncoded ( FromForm )
 
-data AdminStoreCreateForm = AdminStoreCreateForm { adminStoreCreateFormEmail :: EmailAddress }
+data AdminStoreCreateForm =
+    AdminStoreCreateForm
+        { storeEmail :: EmailAddress }
+    deriving (Data, Eq, Generic, Show, Typeable)
+
+instance FromForm AdminStoreCreateForm

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -1,0 +1,13 @@
+{-|
+Module      : Kucipong.Form
+Description : Data types representing data that can be sent to POST handlers.
+Stability   : experimental
+Portability : POSIX
+-}
+
+module Kucipong.Form where
+
+import Kucipong.Prelude
+
+
+data AdminStoreCreateForm = AdminStoreCreateForm { adminStoreCreateFormEmail :: EmailAddress }

--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -4,9 +4,11 @@ module Kucipong.Handler where
 import Kucipong.Prelude
 
 import Data.HVect ( HVect(HNil) )
+import Web.Routing.Combinators ( PathState(Open) )
 import Web.Spock
-    ( ActionCtxT, Path, (<//>), get, html, prehook, root, runSpock, spockT, subcomponent
-    , text, var )
+    ( ActionCtxT, Path, (<//>), getContext, html
+    , root, redirect, renderRoute, runSpock, setStatus, text, var )
+import Web.Spock.Core ( SpockCtxT, spockT, get, post, prehook, subcomponent )
 
 import Kucipong.Config ( Config )
 import Kucipong.Handler.Admin ( adminComponent, adminUrlPrefix )

--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -10,6 +10,7 @@ import Web.Spock
 
 import Kucipong.Config ( Config )
 import Kucipong.Handler.Admin ( adminComponent, adminUrlPrefix )
+import Kucipong.Handler.Store ( storeComponent, storeUrlPrefix )
 import Kucipong.Host ( HasPort(..) )
 import Kucipong.Monad ( KucipongM, runKucipongM )
 
@@ -17,13 +18,6 @@ import Kucipong.Monad ( KucipongM, runKucipongM )
 import Kucipong.Email
 import Mail.Hailgun
 import "emailaddress" Text.Email.Validate (emailAddress)
-
-
-helloR :: Path '[Text]
-helloR = "hello" <//> var
-
-addR :: Path '[Int, Int]
-addR = "calculator" <//> var <//> "+" <//> var
 
 runKucipongMHandleErrors :: Config -> KucipongM a -> IO a
 runKucipongMHandleErrors config = either throwIO pure <=< runKucipongM config
@@ -34,18 +28,8 @@ baseHook = pure HNil
 app :: Config -> IO ()
 app config = runSpock (getPort config) $
     spockT (runKucipongMHandleErrors config) $ do
-        prehook baseHook $
+        prehook baseHook $ do
             subcomponent adminUrlPrefix adminComponent
+            subcomponent storeUrlPrefix storeComponent
         get root $ do
-            -- dbLoginUser undefined undefined
             html "<p>hello world</p>"
-        get helloR $ \name -> text $ "Hello " <> name <> "!"
-        get addR $ \a b -> text . pack $ show (a + b)
-        -- TODO: Remove this.  This is just an example of how to send email.
-        get "sendemail" $ do
-            res <- liftIO $ runKucipongM config $ do
-                mailgunContext <- reader getHailgunContext
-                print mailgunContext
-                resp <- sendRegistrationCompletedEmail (fromMaybe undefined $ emailAddress "kucipong.dev@gmail.com")
-                print resp
-            print res

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -12,18 +12,20 @@ import Database.Persist ( Entity(..) )
 import Network.HTTP.Types ( forbidden403 )
 import Text.EDE ( eitherParse, eitherRender, fromPairs )
 import Web.Spock
-    ( ActionCtxT, Path, SpockCtxT, (<//>), get, getContext, html, prehook, root
-    , redirect, renderRoute, runSpock, setStatus, spockT, text, var )
+    ( ActionCtxT, Path, SpockCtxT, (<//>), get, getContext, html, post, prehook
+    , root, redirect, renderRoute, runSpock, setStatus, spockT, text, var )
 
 import Kucipong.Db
     ( Admin, AdminId, AdminLoginToken, Key(..), LoginTokenExpirationTime(..)
     , adminLoginTokenExpirationTime )
+import Kucipong.Form ( AdminStoreCreateForm )
 import Kucipong.LoginToken ( LoginToken )
 import Kucipong.Monad
     ( MonadKucipongCookie, MonadKucipongDb(..), MonadKucipongSendEmail )
 import Kucipong.RenderTemplate ( renderTemplateFromEnv )
 import Kucipong.Spock
-    ( ContainsAdminSession, getAdminCookie, getAdminEmail, setAdminCookie )
+    ( ContainsAdminSession, getAdminCookie, getAdminEmail, getReqParam
+    , setAdminCookie )
 import Kucipong.Session ( Admin, Session(..) )
 import Kucipong.Util ( fromEitherM, fromMaybeM )
 
@@ -31,23 +33,26 @@ import Kucipong.Util ( fromEitherM, fromMaybeM )
 adminUrlPrefix :: Path '[]
 adminUrlPrefix = "admin"
 
-loginPageR :: Path '[]
-loginPageR = "login"
+loginR :: Path '[]
+loginR = "login"
 
 doLoginR :: Path '[LoginToken]
-doLoginR = "login" <//> var
+doLoginR = loginR <//> var
 
-loginPage
+storeCreateR :: Path '[]
+storeCreateR = "store" <//> "create"
+
+loginGet
     :: forall ctx m
      . ( MonadIO m
        )
     => ActionCtxT ctx m ()
-loginPage =
+loginGet =
     $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs []
 
 -- | Login an admin.  Take the admin's 'LoginToken', and send them a session
 -- cookie.
-doLogin
+doLoginGet
     :: forall ctx m
      . ( MonadIO m
        , MonadKucipongCookie m
@@ -55,7 +60,7 @@ doLogin
        , MonadTime m
        )
     => LoginToken -> ActionCtxT ctx m ()
-doLogin loginToken = do
+doLoginGet loginToken = do
     maybeAdminLoginTokenEntity <- dbFindAdminLoginToken loginToken
     (Entity (AdminLoginTokenKey (AdminKey adminEmail)) adminLoginToken) <-
         fromMaybeM noAdminLoginTokenError maybeAdminLoginTokenEntity
@@ -69,24 +74,36 @@ doLogin loginToken = do
   where
     noAdminLoginTokenError :: ActionCtxT ctx m a
     noAdminLoginTokenError =
-        redirect . renderRoute $ adminUrlPrefix <//> loginPageR
+        redirect . renderRoute $ adminUrlPrefix <//> loginR
 
     tokenExpiredError :: ActionCtxT ctx m a
     tokenExpiredError =
-        redirect . renderRoute $ adminUrlPrefix <//> loginPageR
+        redirect . renderRoute $ adminUrlPrefix <//> loginR
 
 -- | Return the store create page for an admin.
-storeCreate
+storeCreateGet
     :: forall xs n m
      . ( ContainsAdminSession n xs
        , MonadIO m
        , MonadLogger m
        )
     => ActionCtxT (HVect xs) m ()
-storeCreate = do
+storeCreateGet = do
     (AdminSession email) <- getAdminEmail
     $(renderTemplateFromEnv "adminUser_admin_store_create.html") $ fromPairs
         [ "adminEmail" .= email ]
+
+storeCreatePost
+    :: forall xs n m
+     . ( ContainsAdminSession n xs
+       , MonadIO m
+       , MonadLogger m
+       )
+    => ActionCtxT (HVect xs) m ()
+storeCreatePost = do
+    (AdminSession email) <- getAdminEmail
+    (storeCreateForm :: AdminStoreCreateForm) <- getReqParam
+    redirect $ renderRoute root
 
 adminAuthHook
     :: ( MonadIO m
@@ -97,7 +114,7 @@ adminAuthHook = do
     maybeAdminSession <- getAdminCookie
     case maybeAdminSession of
         Nothing ->
-            redirect . renderRoute $ adminUrlPrefix <//> loginPageR
+            redirect . renderRoute $ adminUrlPrefix <//> loginR
         Just adminSession -> do
             oldCtx <- getContext
             return $ adminSession :&: oldCtx
@@ -113,7 +130,9 @@ adminComponent
        )
     => SpockCtxT (HVect xs) m ()
 adminComponent = do
-    get doLoginR doLogin
-    get loginPageR loginPage
-    prehook adminAuthHook $
-        get ("store" <//> "create") storeCreate
+    get doLoginR doLoginGet
+    get loginR loginGet
+    prehook adminAuthHook $ do
+        get storeCreateR storeCreateGet
+        post storeCreateR storeCreatePost
+

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -69,7 +69,7 @@ doLoginGet loginToken = do
     -- check date on admin login token
     now <- currentTime
     let (LoginTokenExpirationTime expirationTime) =
-            adminLoginToken ^. adminLoginTokenExpirationTime
+            adminLoginTokenExpirationTime adminLoginToken
     when (now > expirationTime) tokenExpiredError
     setAdminCookie adminEmail
     redirect $ renderRoute root

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -4,6 +4,7 @@ module Kucipong.Handler.Admin where
 
 import Kucipong.Prelude
 
+import Control.FromSum ( fromEitherM, fromMaybeM )
 import Control.Lens ( (^.) )
 import Control.Monad.Time ( MonadTime(..) )
 import Data.Aeson ( (.=) )
@@ -29,7 +30,6 @@ import Kucipong.Spock
     ( ContainsAdminSession, getAdminCookie, getAdminEmail, getReqParam
     , setAdminCookie )
 import Kucipong.Session ( Admin, Session(..) )
-import Kucipong.Util ( fromEitherM, fromMaybeM )
 
 -- | Url prefix for all of the following 'Path's.
 adminUrlPrefix :: Path '[] 'Open

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -11,9 +11,11 @@ import Data.HVect ( HVect(..) )
 import Database.Persist ( Entity(..) )
 import Network.HTTP.Types ( forbidden403 )
 import Text.EDE ( eitherParse, eitherRender, fromPairs )
+import Web.Routing.Combinators ( PathState(Open) )
 import Web.Spock
-    ( ActionCtxT, Path, SpockCtxT, (<//>), get, getContext, html, post, prehook
-    , root, redirect, renderRoute, runSpock, setStatus, spockT, text, var )
+    ( ActionCtxT, Path, (<//>), getContext, html
+    , root, redirect, renderRoute, runSpock, setStatus, text, var )
+import Web.Spock.Core ( SpockCtxT, spockT, get, post, prehook )
 
 import Kucipong.Db
     ( Admin, AdminId, AdminLoginToken, Key(..), LoginTokenExpirationTime(..)
@@ -30,16 +32,16 @@ import Kucipong.Session ( Admin, Session(..) )
 import Kucipong.Util ( fromEitherM, fromMaybeM )
 
 -- | Url prefix for all of the following 'Path's.
-adminUrlPrefix :: Path '[]
+adminUrlPrefix :: Path '[] 'Open
 adminUrlPrefix = "admin"
 
-loginR :: Path '[]
+loginR :: Path '[] 'Open
 loginR = "login"
 
-doLoginR :: Path '[LoginToken]
+doLoginR :: Path '[LoginToken] 'Open
 doLoginR = loginR <//> var
 
-storeCreateR :: Path '[]
+storeCreateR :: Path '[] 'Open
 storeCreateR = "store" <//> "create"
 
 loginGet

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -21,7 +21,7 @@ import Web.Spock.Core ( SpockCtxT, spockT, get, post, prehook )
 import Kucipong.Db
     ( Admin, AdminId, AdminLoginToken, Key(..), LoginTokenExpirationTime(..)
     , adminLoginTokenExpirationTime )
-import Kucipong.Form ( AdminStoreCreateForm )
+import Kucipong.Form ( AdminStoreCreateForm(AdminStoreCreateForm) )
 import Kucipong.LoginToken ( LoginToken )
 import Kucipong.Monad
     ( MonadKucipongCookie, MonadKucipongDb(..), MonadKucipongSendEmail )
@@ -99,12 +99,15 @@ storeCreatePost
     :: forall xs n m
      . ( ContainsAdminSession n xs
        , MonadIO m
+       , MonadKucipongDb m
        , MonadLogger m
        )
     => ActionCtxT (HVect xs) m ()
 storeCreatePost = do
     (AdminSession email) <- getAdminEmail
-    (storeCreateForm :: AdminStoreCreateForm) <- getReqParam
+    (AdminStoreCreateForm storeEmail) <- getReqParam
+    dbCreateStoreEmail storeEmail
+    -- TODO: Where to redirect this?
     redirect $ renderRoute root
 
 adminAuthHook

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -114,8 +114,7 @@ storeCreatePost = do
     sendStoreLoginEmail
         (storeEmailEmail storeEmail)
         (storeLoginTokenLoginToken storeLoginToken)
-    -- TODO: Where to redirect this?
-    redirect $ renderRoute root
+    redirect . renderRoute $ adminUrlPrefix <//> storeCreateR
 
 adminAuthHook
     :: ( MonadIO m

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -4,6 +4,7 @@ module Kucipong.Handler.Store where
 
 import Kucipong.Prelude
 
+import Control.FromSum ( fromEitherM, fromMaybeM )
 import Control.Lens ( (^.) )
 import Control.Monad.Time ( MonadTime(..) )
 import Data.Aeson ( (.=) )
@@ -27,7 +28,6 @@ import Kucipong.RenderTemplate ( renderTemplateFromEnv )
 import Kucipong.Spock
     ( ContainsStoreSession, getStoreCookie, getStoreEmail, setStoreCookie )
 import Kucipong.Session ( Store, Session(..) )
-import Kucipong.Util ( fromEitherM, fromMaybeM )
 
 -- | Url prefix for all of the following 'Path's.
 storeUrlPrefix :: Path '[] 'Open

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Kucipong.Handler.Store where
+
+import Kucipong.Prelude
+
+import Control.Lens ( (^.) )
+import Control.Monad.Time ( MonadTime(..) )
+import Data.Aeson ( (.=) )
+import Data.HVect ( HVect(..) )
+import Database.Persist ( Entity(..) )
+import Network.HTTP.Types ( forbidden403 )
+import Text.EDE ( eitherParse, eitherRender, fromPairs )
+import Web.Spock
+    ( ActionCtxT, Path, SpockCtxT, (<//>), get, getContext, html, prehook, root
+    , redirect, renderRoute, runSpock, setStatus, spockT, text, var )
+
+import Kucipong.Db
+    ( Store, StoreId, StoreLoginToken, Key(..), LoginTokenExpirationTime(..)
+    , storeLoginTokenExpirationTime )
+import Kucipong.LoginToken ( LoginToken )
+import Kucipong.Monad
+    ( MonadKucipongCookie, MonadKucipongDb(..), MonadKucipongSendEmail )
+import Kucipong.RenderTemplate ( renderTemplateFromEnv )
+import Kucipong.Spock
+    ( ContainsStoreSession, getStoreCookie, getStoreEmail, setStoreCookie )
+import Kucipong.Session ( Store, Session(..) )
+import Kucipong.Util ( fromEitherM, fromMaybeM )
+
+-- | Url prefix for all of the following 'Path's.
+storeUrlPrefix :: Path '[]
+storeUrlPrefix = "store"
+
+loginPageR :: Path '[]
+loginPageR = "login"
+
+doLoginR :: Path '[LoginToken]
+doLoginR = "login" <//> var
+
+loginPage
+    :: forall ctx m
+     . ( MonadIO m
+       )
+    => ActionCtxT ctx m ()
+loginPage =
+    $(renderTemplateFromEnv "storeUser_login.html") $ fromPairs []
+
+-- | Login an store.  Take the store's 'LoginToken', and send them a session
+-- cookie.
+doLogin
+    :: forall ctx m
+     . ( MonadIO m
+       , MonadKucipongCookie m
+       , MonadKucipongDb m
+       , MonadTime m
+       )
+    => LoginToken -> ActionCtxT ctx m ()
+doLogin loginToken = do
+    maybeStoreLoginTokenEntity <- dbFindStoreLoginToken loginToken
+    (Entity (StoreLoginTokenKey (StoreKey storeEmail)) storeLoginToken) <-
+        fromMaybeM noStoreLoginTokenError maybeStoreLoginTokenEntity
+    -- check date on store login token
+    now <- currentTime
+    let (LoginTokenExpirationTime expirationTime) =
+            storeLoginToken ^. storeLoginTokenExpirationTime
+    when (now > expirationTime) tokenExpiredError
+    setStoreCookie storeEmail
+    redirect $ renderRoute root
+  where
+    noStoreLoginTokenError :: ActionCtxT ctx m a
+    noStoreLoginTokenError =
+        redirect . renderRoute $ storeUrlPrefix <//> loginPageR
+
+    tokenExpiredError :: ActionCtxT ctx m a
+    tokenExpiredError =
+        redirect . renderRoute $ storeUrlPrefix <//> loginPageR
+
+storeAuthHook
+    :: ( MonadIO m
+       , MonadKucipongCookie m
+       )
+    => ActionCtxT (HVect xs) m (HVect ((Session Kucipong.Session.Store) ': xs))
+storeAuthHook = do
+    maybeStoreSession <- getStoreCookie
+    case maybeStoreSession of
+        Nothing ->
+            redirect . renderRoute $ storeUrlPrefix <//> loginPageR
+        Just storeSession -> do
+            oldCtx <- getContext
+            return $ storeSession :&: oldCtx
+
+-- TODO: It is better to make some module to share functions with admin handler.
+storeComponent
+    :: forall m xs
+     . ( MonadIO m
+       , MonadKucipongCookie m
+       , MonadKucipongDb m
+       , MonadKucipongSendEmail m
+       , MonadLogger m
+       , MonadTime m
+       )
+    => SpockCtxT (HVect xs) m ()
+storeComponent = do
+    get doLoginR doLogin
+    get loginPageR loginPage
+    -- prehook storeAuthHook $
+    --     get ("store" <//> "something") someAction

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -11,9 +11,11 @@ import Data.HVect ( HVect(..) )
 import Database.Persist ( Entity(..) )
 import Network.HTTP.Types ( forbidden403 )
 import Text.EDE ( eitherParse, eitherRender, fromPairs )
+import Web.Routing.Combinators ( PathState(Open) )
 import Web.Spock
-    ( ActionCtxT, Path, SpockCtxT, (<//>), get, getContext, html, prehook, root
-    , redirect, renderRoute, runSpock, setStatus, spockT, text, var )
+    ( ActionCtxT, Path, (<//>), getContext, html
+    , root, redirect, renderRoute, runSpock, setStatus, text, var )
+import Web.Spock.Core ( SpockCtxT, spockT, get, post, prehook )
 
 import Kucipong.Db
     ( Store, StoreId, StoreLoginToken, Key(..), LoginTokenExpirationTime(..)
@@ -28,13 +30,13 @@ import Kucipong.Session ( Store, Session(..) )
 import Kucipong.Util ( fromEitherM, fromMaybeM )
 
 -- | Url prefix for all of the following 'Path's.
-storeUrlPrefix :: Path '[]
+storeUrlPrefix :: Path '[] 'Open
 storeUrlPrefix = "store"
 
-loginPageR :: Path '[]
+loginPageR :: Path '[] 'Open
 loginPageR = "login"
 
-doLoginR :: Path '[LoginToken]
+doLoginR :: Path '[LoginToken] 'Open
 doLoginR = loginPageR <//> var
 
 loginPage

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -64,7 +64,7 @@ doLogin loginToken = do
     -- check date on store login token
     now <- currentTime
     let (LoginTokenExpirationTime expirationTime) =
-            storeLoginToken ^. storeLoginTokenExpirationTime
+            storeLoginTokenExpirationTime storeLoginToken
     when (now > expirationTime) tokenExpiredError
     setStoreCookie storeEmail
     redirect $ renderRoute root

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -35,7 +35,7 @@ loginPageR :: Path '[]
 loginPageR = "login"
 
 doLoginR :: Path '[LoginToken]
-doLoginR = "login" <//> var
+doLoginR = loginPageR <//> var
 
 loginPage
     :: forall ctx m
@@ -57,7 +57,7 @@ doLogin
     => LoginToken -> ActionCtxT ctx m ()
 doLogin loginToken = do
     maybeStoreLoginTokenEntity <- dbFindStoreLoginToken loginToken
-    (Entity (StoreLoginTokenKey (StoreKey storeEmail)) storeLoginToken) <-
+    (Entity (StoreLoginTokenKey (StoreEmailKey storeEmail)) storeLoginToken) <-
         fromMaybeM noStoreLoginTokenError maybeStoreLoginTokenEntity
     -- check date on store login token
     now <- currentTime

--- a/src/Kucipong/Monad.hs
+++ b/src/Kucipong/Monad.hs
@@ -32,11 +32,13 @@ type MonadKucipong' m =
 -- | This constraint synonym wraps up all of the type classes used by 'KucipongM'.
 type MonadKucipong m =
     ( MonadBaseControl IO m
+    , MonadCatch m
     , MonadError AppErr m
     , MonadIO m
     , MonadLogger m
     , MonadRandom m
     , MonadReader Config m
+    , MonadThrow m
     , MonadTime m
     , MonadKucipong' m
     )
@@ -51,11 +53,13 @@ newtype KucipongT m a = KucipongT
         , Functor
         , Monad
         , MonadBase b
+        , MonadCatch
         , MonadError e
         , MonadIO
         , MonadLogger
         , MonadRandom
         , MonadReader r
+        , MonadThrow
         , MonadTime
         )
 
@@ -118,11 +122,13 @@ newtype KucipongM a = KucipongM
         , Functor
         , Monad
         , MonadBase IO
+        , MonadCatch
         , MonadError AppErr
         , MonadIO
         , MonadLogger
         , MonadRandom
         , MonadReader Config
+        , MonadThrow
         , MonadTime
         , MonadKucipongCookie
         , MonadKucipongDb

--- a/src/Kucipong/Monad/Cookie/Trans.hs
+++ b/src/Kucipong/Monad/Cookie/Trans.hs
@@ -18,11 +18,13 @@ newtype KucipongCookieT m a = KucipongCookieT { unKucipongCookieT :: IdentityT m
         , Functor
         , Monad
         , MonadBase b
+        , MonadCatch
         , MonadError e
         , MonadIO
         , MonadLogger
         , MonadRandom
         , MonadReader r
+        , MonadThrow
         , MonadTime
         , MonadTrans
         )

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -77,7 +77,7 @@ instance ( MonadBaseControl IO m
             case maybeExistingAdminVal of
                 Just existingAdminVal -> do
                     -- admin already exists.  update the name if it is different
-                    if (existingAdminVal ^. adminName /= name)
+                    if (adminName existingAdminVal /= name)
                         then do
                             newAdminVal <- updateGet (AdminKey email) [AdminName =. name]
                             pure $ Entity (AdminKey email) newAdminVal

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -14,8 +14,8 @@ import Database.Persist
 import Kucipong.Config ( Config )
 import Kucipong.Db
     ( Admin(..), AdminLoginToken(..), CreatedTime(..), EntityField(..), Key(..)
-    , LoginTokenExpirationTime(..), UpdatedTime(..), adminName, runDb
-    , runDbCurrTime )
+    , LoginTokenExpirationTime(..), Store(..), StoreLoginToken(..)
+    , UpdatedTime(..), adminName, runDb, runDbCurrTime, storeName )
 import Kucipong.Errors ( AppErr )
 import Kucipong.LoginToken ( LoginToken, createRandomLoginToken )
 import Kucipong.Monad.Db.Class ( MonadKucipongDb(..) )
@@ -30,6 +30,9 @@ instance ( MonadBaseControl IO m
          , MonadTime m
          ) => MonadKucipongDb (KucipongDbT m) where
 
+    -- ===========
+    --  For Admin
+    -- ===========
     dbCreateAdmin :: EmailAddress -> Text -> KucipongDbT m (Entity Admin)
     dbCreateAdmin email name = lift go
       where
@@ -85,3 +88,66 @@ instance ( MonadBaseControl IO m
                             (UpdatedTime currTime) Nothing name
                     newAdminKey <- insert newAdminVal
                     pure $ Entity newAdminKey newAdminVal
+
+    -- ===========
+    --  For Store
+    -- ===========
+    dbCreateStore :: EmailAddress -> Text -> KucipongDbT m (Entity Store)
+    dbCreateStore email name = lift go
+      where
+        go :: m (Entity Store)
+        go = do
+            currTime <- currentTime
+            let store =
+                    Store email (CreatedTime currTime) (UpdatedTime currTime)
+                        Nothing name
+                        Nothing Nothing Nothing Nothing Nothing Nothing
+                        Nothing Nothing Nothing
+            storeKey <- runDb $ insert store
+            pure $ Entity storeKey store
+
+    dbCreateStoreMagicLoginToken :: Key Store -> KucipongDbT m (Entity StoreLoginToken)
+    dbCreateStoreMagicLoginToken storeKey = lift go
+      where
+        go :: m (Entity StoreLoginToken)
+        go = do
+            currTime <- currentTime
+            randomLoginToken <- createRandomLoginToken
+            let plusOneDay = addOneDay currTime
+            let newStoreLoginTokenVal =
+                    StoreLoginToken storeKey (CreatedTime currTime)
+                        (UpdatedTime currTime) Nothing randomLoginToken
+                        (LoginTokenExpirationTime plusOneDay)
+            runDb $ repsert (StoreLoginTokenKey storeKey) newStoreLoginTokenVal
+            pure $ Entity (StoreLoginTokenKey storeKey) newStoreLoginTokenVal
+
+    dbFindStoreLoginToken :: LoginToken -> KucipongDbT m (Maybe (Entity StoreLoginToken))
+    dbFindStoreLoginToken loginToken = lift go
+      where
+        go :: m (Maybe (Entity StoreLoginToken))
+        go = runDb $ selectFirst [StoreLoginTokenLoginToken ==. loginToken] []
+
+    dbUpsertStore :: EmailAddress -> Text -> KucipongDbT m (Entity Store)
+    dbUpsertStore email name = lift go
+      where
+        go :: m (Entity Store)
+        go = runDbCurrTime $ \currTime -> do
+            maybeExistingStoreVal <- get (StoreKey email)
+            case maybeExistingStoreVal of
+                Just existingStoreVal -> do
+                    -- store already exists.  update the name if it is different
+                    if (existingStoreVal ^. storeName /= name)
+                        then do
+                            newStoreVal <- updateGet (StoreKey email) [StoreName =. name]
+                            pure $ Entity (StoreKey email) newStoreVal
+                        else
+                            pure $ Entity (StoreKey email) existingStoreVal
+                Nothing -> do
+                    -- couldn't find an existing store, so we will create a new
+                    -- one
+                    let newStoreVal = Store email (CreatedTime currTime)
+                            (UpdatedTime currTime) Nothing name
+                            Nothing Nothing Nothing Nothing Nothing Nothing
+                            Nothing Nothing Nothing
+                    newStoreKey <- insert newStoreVal
+                    pure $ Entity newStoreKey newStoreVal

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -9,17 +9,20 @@ import Control.Lens ( (^.) )
 import Control.Monad.Random ( MonadRandom(..) )
 import Control.Monad.Time ( MonadTime(..) )
 import Database.Persist
-    ( Entity(..), (==.), (=.), get, insert, repsert, selectFirst, updateGet )
+    ( Entity(..), (==.), (=.), get, insert, insertEntity, repsert, selectFirst
+    , updateGet )
 
 import Kucipong.Config ( Config )
 import Kucipong.Db
-    ( Admin(..), AdminLoginToken(..), CreatedTime(..), EntityField(..), Key(..)
-    , LoginTokenExpirationTime(..), Store(..), StoreLoginToken(..)
-    , UpdatedTime(..), adminName, runDb, runDbCurrTime, storeName )
+    ( Admin(..), AdminLoginToken(..), CreatedTime(..), EntityField(..)
+    , Image(..), Key(..), LoginTokenExpirationTime(..), Store(..)
+    , StoreEmail(..), StoreLoginToken(..), UpdatedTime(..), adminName, runDb
+    , runDbCurrTime, storeName )
 import Kucipong.Errors ( AppErr )
 import Kucipong.LoginToken ( LoginToken, createRandomLoginToken )
 import Kucipong.Monad.Db.Class ( MonadKucipongDb(..) )
 import Kucipong.Monad.Db.Trans ( KucipongDbT(..) )
+import Kucipong.Persist ( repsertEntity )
 import Kucipong.Util ( addOneDay )
 
 instance ( MonadBaseControl IO m
@@ -57,8 +60,7 @@ instance ( MonadBaseControl IO m
                     AdminLoginToken adminKey (CreatedTime currTime)
                         (UpdatedTime currTime) Nothing randomLoginToken
                         (LoginTokenExpirationTime plusOneDay)
-            runDb $ repsert (AdminLoginTokenKey adminKey) newAdminLoginTokenVal
-            pure $ Entity (AdminLoginTokenKey adminKey) newAdminLoginTokenVal
+            runDb $ repsertEntity (AdminLoginTokenKey adminKey) newAdminLoginTokenVal
 
     dbFindAdminLoginToken :: LoginToken -> KucipongDbT m (Maybe (Entity AdminLoginToken))
     dbFindAdminLoginToken loginToken = lift go
@@ -92,22 +94,56 @@ instance ( MonadBaseControl IO m
     -- ===========
     --  For Store
     -- ===========
-    dbCreateStore :: EmailAddress -> Text -> KucipongDbT m (Entity Store)
-    dbCreateStore email name = lift go
+    dbCreateStore
+        :: Key StoreEmail
+        -- ^ 'Key' for the 'StoreEmail'
+        -> Text
+        -- ^ 'Store' name
+        -> Text
+        -- ^ 'Store' category
+        -> Text
+        -- ^ 'Store' category detail
+        -> Maybe Image
+        -- ^ 'Image' for the 'Store'
+        -> Maybe Text
+        -- ^ Sales Point for the 'Store'
+        -> Maybe Text
+        -- ^ Address for the 'Store'
+        -> Maybe Text
+        -- ^ Phone number for the 'Store'
+        -> Maybe Text
+        -- ^ Business hours for the 'Store'
+        -> Maybe Text
+        -- ^ Regular holiday for the 'Store'
+        -> Maybe Text
+        -- ^ url for the 'Store'
+        -> KucipongDbT m (Entity Store)
+    dbCreateStore storeEmailKey name category catdet image salesPoint address phoneNumber
+            businessHours regularHoliday url = lift go
       where
         go :: m (Entity Store)
         go = do
             currTime <- currentTime
             let store =
-                    Store email (CreatedTime currTime) (UpdatedTime currTime)
-                        Nothing name
-                        Nothing Nothing Nothing Nothing Nothing Nothing
-                        Nothing Nothing Nothing
-            storeKey <- runDb $ insert store
-            pure $ Entity storeKey store
+                    Store storeEmailKey (CreatedTime currTime)
+                        (UpdatedTime currTime) Nothing name category catdet
+                        image salesPoint address phoneNumber businessHours
+                        regularHoliday url
+            runDb $ repsertEntity (StoreKey storeEmailKey) store
 
-    dbCreateStoreMagicLoginToken :: Key Store -> KucipongDbT m (Entity StoreLoginToken)
-    dbCreateStoreMagicLoginToken storeKey = lift go
+    dbCreateStoreEmail :: EmailAddress -> KucipongDbT m (Entity StoreEmail)
+    dbCreateStoreEmail email = lift go
+      where
+        go :: m (Entity StoreEmail)
+        go = do
+            currTime <- currentTime
+            let storeEmail =
+                    StoreEmail email (CreatedTime currTime) (UpdatedTime currTime)
+                        Nothing
+            runDb $ insertEntity storeEmail
+
+    dbCreateStoreMagicLoginToken :: Key StoreEmail -> KucipongDbT m (Entity StoreLoginToken)
+    dbCreateStoreMagicLoginToken storeEmailKey = lift go
       where
         go :: m (Entity StoreLoginToken)
         go = do
@@ -115,11 +151,11 @@ instance ( MonadBaseControl IO m
             randomLoginToken <- createRandomLoginToken
             let plusOneDay = addOneDay currTime
             let newStoreLoginTokenVal =
-                    StoreLoginToken storeKey (CreatedTime currTime)
+                    StoreLoginToken storeEmailKey (CreatedTime currTime)
                         (UpdatedTime currTime) Nothing randomLoginToken
                         (LoginTokenExpirationTime plusOneDay)
-            runDb $ repsert (StoreLoginTokenKey storeKey) newStoreLoginTokenVal
-            pure $ Entity (StoreLoginTokenKey storeKey) newStoreLoginTokenVal
+            runDb $ repsert (StoreLoginTokenKey storeEmailKey) newStoreLoginTokenVal
+            pure $ Entity (StoreLoginTokenKey storeEmailKey) newStoreLoginTokenVal
 
     dbFindStoreLoginToken :: LoginToken -> KucipongDbT m (Maybe (Entity StoreLoginToken))
     dbFindStoreLoginToken loginToken = lift go
@@ -127,27 +163,27 @@ instance ( MonadBaseControl IO m
         go :: m (Maybe (Entity StoreLoginToken))
         go = runDb $ selectFirst [StoreLoginTokenLoginToken ==. loginToken] []
 
-    dbUpsertStore :: EmailAddress -> Text -> KucipongDbT m (Entity Store)
-    dbUpsertStore email name = lift go
-      where
-        go :: m (Entity Store)
-        go = runDbCurrTime $ \currTime -> do
-            maybeExistingStoreVal <- get (StoreKey email)
-            case maybeExistingStoreVal of
-                Just existingStoreVal -> do
-                    -- store already exists.  update the name if it is different
-                    if (existingStoreVal ^. storeName /= name)
-                        then do
-                            newStoreVal <- updateGet (StoreKey email) [StoreName =. name]
-                            pure $ Entity (StoreKey email) newStoreVal
-                        else
-                            pure $ Entity (StoreKey email) existingStoreVal
-                Nothing -> do
-                    -- couldn't find an existing store, so we will create a new
-                    -- one
-                    let newStoreVal = Store email (CreatedTime currTime)
-                            (UpdatedTime currTime) Nothing name
-                            Nothing Nothing Nothing Nothing Nothing Nothing
-                            Nothing Nothing Nothing
-                    newStoreKey <- insert newStoreVal
-                    pure $ Entity newStoreKey newStoreVal
+    -- dbUpsertStore :: EmailAddress -> Text -> KucipongDbT m (Entity Store)
+    -- dbUpsertStore email name = lift go
+    --   where
+    --     go :: m (Entity Store)
+    --     go = runDbCurrTime $ \currTime -> do
+    --         maybeExistingStoreVal <- get (StoreKey email)
+    --         case maybeExistingStoreVal of
+    --             Just existingStoreVal -> do
+    --                 -- store already exists.  update the name if it is different
+    --                 if (existingStoreVal ^. storeName /= name)
+    --                     then do
+    --                         newStoreVal <- updateGet (StoreKey email) [StoreName =. name]
+    --                         pure $ Entity (StoreKey email) newStoreVal
+    --                     else
+    --                         pure $ Entity (StoreKey email) existingStoreVal
+    --             Nothing -> do
+    --                 -- couldn't find an existing store, so we will create a new
+    --                 -- one
+    --                 let newStoreVal = Store email (CreatedTime currTime)
+    --                         (UpdatedTime currTime) Nothing name
+    --                         Nothing Nothing Nothing Nothing Nothing Nothing
+    --                         Nothing Nothing Nothing
+    --                 newStoreKey <- insert newStoreVal
+    --                 pure $ Entity newStoreKey newStoreVal

--- a/src/Kucipong/Monad/Db/Trans.hs
+++ b/src/Kucipong/Monad/Db/Trans.hs
@@ -17,11 +17,13 @@ newtype KucipongDbT m a = KucipongDbT { unKucipongDbT :: IdentityT m a }
         , Functor
         , Monad
         , MonadBase b
+        , MonadCatch
         , MonadError e
         , MonadIO
         , MonadLogger
         , MonadRandom
         , MonadReader r
+        , MonadThrow
         , MonadTime
         , MonadTrans
         )

--- a/src/Kucipong/Monad/SendEmail/Class.hs
+++ b/src/Kucipong/Monad/SendEmail/Class.hs
@@ -28,6 +28,19 @@ class Monad m => MonadKucipongSendEmail m where
         => EmailAddress -> LoginToken -> t n ()
     sendAdminLoginEmail = (lift .) . sendAdminLoginEmail
 
+    sendStoreLoginEmail
+        :: EmailAddress
+        -> LoginToken
+        -> m ()
+    default sendStoreLoginEmail
+        :: ( Monad (t n)
+           , MonadKucipongSendEmail n
+           , MonadTrans t
+           , m ~ t n
+           )
+        => EmailAddress -> LoginToken -> t n ()
+    sendStoreLoginEmail = (lift .) . sendStoreLoginEmail
+
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ActionCtxT ctx m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ExceptT e m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (IdentityT m)

--- a/src/Kucipong/Monad/SendEmail/Instance.hs
+++ b/src/Kucipong/Monad/SendEmail/Instance.hs
@@ -24,3 +24,6 @@ instance
 
     sendAdminLoginEmail :: EmailAddress -> LoginToken -> KucipongSendEmailT m ()
     sendAdminLoginEmail = (void .) . Email.sendAdminLoginEmail
+
+    sendStoreLoginEmail :: EmailAddress -> LoginToken -> KucipongSendEmailT m ()
+    sendStoreLoginEmail = (void .) . Email.sendStoreLoginEmail

--- a/src/Kucipong/Monad/SendEmail/Trans.hs
+++ b/src/Kucipong/Monad/SendEmail/Trans.hs
@@ -18,11 +18,13 @@ newtype KucipongSendEmailT m a = KucipongSendEmailT { unKucipongSendEmailT :: Id
         , Functor
         , Monad
         , MonadBase b
+        , MonadCatch
         , MonadError e
         , MonadIO
         , MonadLogger
         , MonadRandom
         , MonadReader r
+        , MonadThrow
         , MonadTime
         , MonadTrans
         )

--- a/src/Kucipong/Persist.hs
+++ b/src/Kucipong/Persist.hs
@@ -4,16 +4,15 @@ module Kucipong.Persist where
 import Kucipong.Prelude
 
 import Database.Persist
-    ( Entity(Entity), Key, PersistEntity, PersistEntityBackend, PersistStore
+    ( BaseBackend, Entity(Entity), Key, PersistEntity, PersistEntityBackend, PersistStore, PersistStoreWrite
     , repsert )
 
 repsertEntity
-    :: forall (m :: * -> *) record .
-       ( MonadIO m
-       , PersistStore (PersistEntityBackend record)
+    :: forall backend m record
+     . ( MonadIO m
+       , PersistEntityBackend record ~ BaseBackend backend
        , PersistEntity record
+       , PersistStoreWrite backend
        )
-    => Key record
-    -> record
-    -> ReaderT (PersistEntityBackend record) m (Entity record)
+    => Key record -> record -> ReaderT backend m (Entity record)
 repsertEntity key val = repsert key val $> Entity key val

--- a/src/Kucipong/Persist.hs
+++ b/src/Kucipong/Persist.hs
@@ -1,0 +1,19 @@
+
+module Kucipong.Persist where
+
+import Kucipong.Prelude
+
+import Database.Persist
+    ( Entity(Entity), Key, PersistEntity, PersistEntityBackend, PersistStore
+    , repsert )
+
+repsertEntity
+    :: forall (m :: * -> *) record .
+       ( MonadIO m
+       , PersistStore (PersistEntityBackend record)
+       , PersistEntity record
+       )
+    => Key record
+    -> record
+    -> ReaderT (PersistEntityBackend record) m (Entity record)
+repsertEntity key val = repsert key val $> Entity key val

--- a/src/Kucipong/RenderTemplate.hs
+++ b/src/Kucipong/RenderTemplate.hs
@@ -6,14 +6,13 @@ module Kucipong.RenderTemplate where
 import Kucipong.Prelude hiding ( try )
 
 import Control.Exception ( try )
+import Control.FromSum ( fromEitherM )
 import Language.Haskell.TH
     ( Exp, Q, appE, litE, lookupValueName, mkName, stringL, varE )
 import Language.Haskell.TH.Syntax ( addDependentFile )
 import Network.HTTP.Types ( internalServerError500 )
 import Text.EDE ( Template, eitherParse, eitherRender, fromPairs )
 import Web.Spock ( html, setStatus )
-
-import Kucipong.Util ( fromEitherM )
 
 templateDirectory :: FilePath
 templateDirectory = "frontend" </> "dist"

--- a/src/Kucipong/Spock.hs
+++ b/src/Kucipong/Spock.hs
@@ -1,6 +1,7 @@
 
 module Kucipong.Spock
-    ( setAdminCookie
+    ( module Kucipong.Spock.ReqParam
+    , setAdminCookie
     , setStoreCookie
     , getAdminCookie
     , getStoreCookie
@@ -17,6 +18,7 @@ import Web.Spock ( ActionCtxT, cookie, getContext, setCookie )
 
 import Kucipong.Monad ( MonadKucipongCookie(..) )
 import Kucipong.Session ( Admin, Session(AdminSession, StoreSession), Store )
+import Kucipong.Spock.ReqParam
 
 setAdminCookie
     :: ( MonadIO m

--- a/src/Kucipong/Spock/ReqParam.hs
+++ b/src/Kucipong/Spock/ReqParam.hs
@@ -1,0 +1,34 @@
+{-|
+Module      : Kucipong.Spock.ReqParam
+Description : Helper functions for request parameters.
+Stability   : experimental
+Portability : POSIX
+-}
+
+module Kucipong.Spock.ReqParam where
+
+import Kucipong.Prelude
+
+import Control.FromSum ( fromEitherM )
+import Data.HVect ( HasRep, HVectElim )
+-- import Web.FormUrlEncoded ( urlDecodeAsForm )
+import Web.Spock ( ActionCtxT, Path, SpockCtxT, body, post, redirect, renderRoute, root )
+
+getReqParam
+    :: forall ctx m a
+     . ({- FromForm a, -} MonadIO m)
+    => ActionCtxT ctx m a
+getReqParam = getReqParamErr handleFormDecodeError
+  where
+    handleFormDecodeError :: Text -> ActionCtxT ctx m a
+    handleFormDecodeError _ =
+        -- TODO: How should we handle this error?
+        redirect $ renderRoute root
+
+getReqParamErr
+    :: forall ctx m a
+     . ({- FromForm a, -} MonadIO m)
+     => (Text -> ActionCtxT ctx m a)
+     -> ActionCtxT ctx m a
+-- getReqParamErr errHandler = fromEitherM errHandler . urlDecodeAsForm =<< body
+getReqParamErr errHandler = fromEitherM errHandler . undefined =<< body

--- a/src/Kucipong/Spock/ReqParam.hs
+++ b/src/Kucipong/Spock/ReqParam.hs
@@ -12,7 +12,8 @@ import Kucipong.Prelude
 import Control.FromSum ( fromEitherM )
 import Data.HVect ( HasRep, HVectElim )
 -- import Web.FormUrlEncoded ( urlDecodeAsForm )
-import Web.Spock ( ActionCtxT, Path, SpockCtxT, body, post, redirect, renderRoute, root )
+import Web.Spock ( ActionCtxT, Path, body, post, redirect, renderRoute, root )
+import Web.Spock.Core ( SpockCtxT )
 
 getReqParam
     :: forall ctx m a

--- a/src/Kucipong/Spock/ReqParam.hs
+++ b/src/Kucipong/Spock/ReqParam.hs
@@ -11,13 +11,13 @@ import Kucipong.Prelude
 
 import Control.FromSum ( fromEitherM )
 import Data.HVect ( HasRep, HVectElim )
--- import Web.FormUrlEncoded ( urlDecodeAsForm )
+import Web.FormUrlEncoded ( FromForm, urlDecodeAsForm )
 import Web.Spock ( ActionCtxT, Path, body, post, redirect, renderRoute, root )
 import Web.Spock.Core ( SpockCtxT )
 
 getReqParam
     :: forall ctx m a
-     . ({- FromForm a, -} MonadIO m)
+     . (FromForm a, MonadIO m)
     => ActionCtxT ctx m a
 getReqParam = getReqParamErr handleFormDecodeError
   where
@@ -28,8 +28,7 @@ getReqParam = getReqParamErr handleFormDecodeError
 
 getReqParamErr
     :: forall ctx m a
-     . ({- FromForm a, -} MonadIO m)
+     . (FromForm a, MonadIO m)
      => (Text -> ActionCtxT ctx m a)
      -> ActionCtxT ctx m a
--- getReqParamErr errHandler = fromEitherM errHandler . urlDecodeAsForm =<< body
-getReqParamErr errHandler = fromEitherM errHandler . undefined =<< body
+getReqParamErr errHandler = fromEitherM errHandler . urlDecodeAsForm . fromStrict =<< body

--- a/src/Kucipong/Util.hs
+++ b/src/Kucipong/Util.hs
@@ -14,26 +14,6 @@ import Data.Time.Clock ( NominalDiffTime, addUTCTime )
 
 infixr 8 <$$>
 
--- | Similar to 'fromMaybe'.  @'fromMaybeM' action@ is the same as @'maybe'
--- action 'pure'@.
---
--- >>> fromMaybeM (putStrLn "hello") Nothing
--- hello
--- >>> fromMaybeM (Left "there was an error") (Just 3)
--- Right 3
-fromMaybeM :: Applicative m => m a -> Maybe a -> m a
-fromMaybeM action = maybe action pure
-
--- | Similar to 'fromMaybeM'.  @'fromEitherM' errHandler@ is the same as
--- @'either' errHandler 'pure'@.
---
--- >>> fromEitherM (putStrLn) $ Left "hello"
--- hello
--- >>> fromEitherM (const Nothing) (Right 3)
--- Just 3
-fromEitherM :: Applicative m => (e -> m a) -> Either e a -> m a
-fromEitherM errHandler = either errHandler pure
-
 oneDay :: NominalDiffTime
 oneDay = 60 * 60 * 24
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,6 +15,9 @@ extra-deps:
     # This will probably be available at least by 9/15 in hackage, and in
     # lts-6.15. (Or it might not be available until the next major lts release.)
     - hailgun-0.4.1.0
+    # This should be available in lts-8.
+    # - http-api-data-0.3.1
+    - from-sum-0.1.0.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,13 +10,9 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-    # This might not be available until the next major lts release.
-    - emailaddress-0.1.6.0
-    # This will probably be available at least by 9/15 in hackage, and in
-    # lts-6.15. (Or it might not be available until the next major lts release.)
-    - hailgun-0.4.1.0
     # This should be available in lts-8.
-    # - http-api-data-0.3.1
+    - http-api-data-0.3.1
+    # This should be available in lts-7.3.
     - from-sum-0.1.0.0
 
 # Override default flag values for local packages and extra-deps

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-6.13
+resolver: lts-7.2
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
This PR implements the admin store-create POST handler.

This PR also updates to lts-7 (ghc-8.0.1) in order to use the new http-api-data package for easily parsing http form data.

@arowM Please review.  Especially the `Kucipong.Db.Models.EntityDefs` module.  Let me know what you think.

Closes #9.  Closes #15.
