### PR TITLE
Template params

### DIFF
--- a/frontend/src/pug/_messageArea.pug
+++ b/frontend/src/pug/_messageArea.pug
@@ -1,4 +1,11 @@
 .messageArea
   .messageGroup
+    | {% for error in errors %}
+    .messageBody-error
+      | {{ error.value | toLower }}
+    | {% endfor %}
+
+    | {% for message in messages %}
     .messageBody
-      | バックエンドからのメッセージをここに表示します。
+      | {{ message.value }}
+    | {% endfor %}

--- a/frontend/src/pug/_messageArea.pug
+++ b/frontend/src/pug/_messageArea.pug
@@ -2,10 +2,10 @@
   .messageGroup
     | {% for error in errors %}
     .messageBody-error
-      | {{ error.value | toLower }}
+      | {{ error.value | escape }}
     | {% endfor %}
 
     | {% for message in messages %}
     .messageBody
-      | {{ message.value }}
+      | {{ message.value | escape }}
     | {% endfor %}

--- a/frontend/src/styles/_common.scss
+++ b/frontend/src/styles/_common.scss
@@ -298,16 +298,27 @@ h6 {
 
 .messageArea {
   .messageGroup {
-    padding: 1em;
+    padding: 0.5em 1em;
 
-    .messageBody {
+    .messageBody,
+    .messageBody-error {
       border-radius: 4px;
-      border: solid 2px $main-color;
+      border-style: solid;
+      border-width: 2px;
       box-shadow: 0 18px 15px -22px $shadow-color;
       display: flex;
       justify-content: space-between;
       color: $font-color;
       padding: 0.4em;
+      margin: 0.5em 0;
+    }
+
+    .messageBody {
+      border-color: $main-color;
+    }
+
+    .messageBody-error {
+      border-color: $danger-color;
     }
   }
 }

--- a/frontend/src/styles/_variables.scss
+++ b/frontend/src/styles/_variables.scss
@@ -2,6 +2,7 @@
 $main-color: #07b8eb;
 $second-color: #484848;
 $second-color-light: #eee;
+$danger-color: #ff5858;
 
 $font-color: #000;
 $invert-font-color: #fff;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -30,7 +30,7 @@ const commonConfig = {
   // Directory to output compiled files
   output: {
     path: path.resolve(__dirname, 'dist/'),
-    filename: '[name]-[hash].js',
+    filename: 'static/[name]-[hash].js',
   },
 
   resolve: {
@@ -42,8 +42,9 @@ const commonConfig = {
     noParse: /\.elm$/,
     loaders: [
       {
-        test: /\.(eot|ttf|woff|woff2|svg)$/,
+        test: /\.(eot|ttf|woff|woff2|svg|png|jpg)$/,
         loader: 'file-loader',
+        query: { name: "static/[name]-[hash].[ext]" }
       },
       {
         test: /\.pug$/,
@@ -276,10 +277,6 @@ if (TARGET_ENV === 'production') {
     plugins: [
       new CopyWebpackPlugin([
         {
-          from: 'src/img/',
-          to:   'img/',
-        },
-        {
           from: 'src/favicon.ico'
         },
       ]),
@@ -287,7 +284,7 @@ if (TARGET_ENV === 'production') {
       new webpack.optimize.OccurenceOrderPlugin(),
 
       // Extract CSS into a separate file
-      new ExtractTextPlugin( './[name]-[hash].css', { allChunks: true } ),
+      new ExtractTextPlugin( './static/[name]-[hash].css', { allChunks: true } ),
 
       // Minify & mangle JS/CSS
       new webpack.optimize.UglifyJsPlugin({

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -30,7 +30,7 @@ const commonConfig = {
   // Directory to output compiled files
   output: {
     path: path.resolve(__dirname, 'dist/'),
-    filename: 'static/[name]-[hash].js',
+    filename: '/static/[name]-[hash].js',
   },
 
   resolve: {
@@ -44,7 +44,7 @@ const commonConfig = {
       {
         test: /\.(eot|ttf|woff|woff2|svg|png|jpg)$/,
         loader: 'file-loader',
-        query: { name: "static/[name]-[hash].[ext]" }
+        query: { name: "/static/[name]-[hash].[ext]" }
       },
       {
         test: /\.pug$/,
@@ -284,7 +284,7 @@ if (TARGET_ENV === 'production') {
       new webpack.optimize.OccurenceOrderPlugin(),
 
       // Extract CSS into a separate file
-      new ExtractTextPlugin( './static/[name]-[hash].css', { allChunks: true } ),
+      new ExtractTextPlugin( '/static/[name]-[hash].css', { allChunks: true } ),
 
       // Minify & mangle JS/CSS
       new webpack.optimize.UglifyJsPlugin({

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -96,6 +96,7 @@ library
                      , time
                      , transformers
                      , transformers-base
+                     , unordered-containers
                      , wai
                      , wai-extra
                      , warp

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -30,6 +30,7 @@ library
                      , Kucipong.Handler
                      , Kucipong.Handler.Admin
                      , Kucipong.Handler.Store
+                     , Kucipong.Handler.Static
                      , Kucipong.Host
                      , Kucipong.LoginToken
                      , Kucipong.Monad
@@ -63,6 +64,8 @@ library
                      , emailaddress
                      , envelope
                      , from-sum
+                     , filepath
+                     , Glob
                      , hailgun
                      , HTTP
                      , http-api-data

--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 
 module Kucipong.Handler where
 
@@ -13,6 +14,7 @@ import Web.Spock.Core ( SpockCtxT, spockT, get, post, prehook, subcomponent )
 import Kucipong.Config ( Config )
 import Kucipong.Handler.Admin ( adminComponent, adminUrlPrefix )
 import Kucipong.Handler.Store ( storeComponent, storeUrlPrefix )
+import Kucipong.Handler.Static ( staticComponent' )
 import Kucipong.Host ( HasPort(..) )
 import Kucipong.Monad ( KucipongM, runKucipongM )
 
@@ -30,6 +32,7 @@ baseHook = pure HNil
 app :: Config -> IO ()
 app config = runSpock (getPort config) $
     spockT (runKucipongMHandleErrors config) $ do
+        subcomponent "static" $(staticComponent')
         prehook baseHook $ do
             subcomponent adminUrlPrefix adminComponent
             subcomponent storeUrlPrefix storeComponent

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -76,12 +76,20 @@ doLoginGet loginToken = do
     redirect $ renderRoute root
   where
     noAdminLoginTokenError :: ActionCtxT ctx m a
-    noAdminLoginTokenError =
-        redirect . renderRoute $ adminUrlPrefix <//> loginR
+    noAdminLoginTokenError = do
+        setStatus forbidden403
+        $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
+            [ "errors" .=
+              [ "Failed to log in X(\nPlease try again." :: Text ]
+            ]
 
     tokenExpiredError :: ActionCtxT ctx m a
-    tokenExpiredError =
-        redirect . renderRoute $ adminUrlPrefix <//> loginR
+    tokenExpiredError = do
+        setStatus forbidden403
+        $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
+            [ "errors" .=
+              [ "This log in URL has been expired X(\nPlease try again." :: Text ]
+            ]
 
 -- | Return the store create page for an admin.
 storeCreateGet
@@ -125,7 +133,12 @@ adminAuthHook = do
     maybeAdminSession <- getAdminCookie
     case maybeAdminSession of
         Nothing ->
-            redirect . renderRoute $ adminUrlPrefix <//> loginR
+          $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
+              [ "errors" .=
+                [ "Need to be logged in as admin in order to access this page." :: Text ]
+              , "messages" .=
+                [ "<script>alert(1);</script>" :: Text ]
+              ]
         Just adminSession -> do
             oldCtx <- getContext
             return $ adminSession :&: oldCtx

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -51,7 +51,10 @@ loginGet
        )
     => ActionCtxT ctx m ()
 loginGet =
-    $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs []
+    $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
+        [ "errors" .= (empty :: [Text])
+        , "messages" .= (empty :: [Text])
+        ]
 
 -- | Login an admin.  Take the admin's 'LoginToken', and send them a session
 -- cookie.
@@ -81,6 +84,7 @@ doLoginGet loginToken = do
         $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
             [ "errors" .=
               [ "Failed to log in X(\nPlease try again." :: Text ]
+              , "messages" .= (empty :: [Text])
             ]
 
     tokenExpiredError :: ActionCtxT ctx m a
@@ -89,6 +93,7 @@ doLoginGet loginToken = do
         $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
             [ "errors" .=
               [ "This log in URL has been expired X(\nPlease try again." :: Text ]
+              , "messages" .= (empty :: [Text])
             ]
 
 -- | Return the store create page for an admin.
@@ -136,6 +141,7 @@ adminAuthHook = do
           $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
               [ "errors" .=
                 [ "Need to be logged in as admin in order to access this page." :: Text ]
+              , "messages" .= (empty :: [Text])
               ]
         Just adminSession -> do
             oldCtx <- getContext

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -136,8 +136,6 @@ adminAuthHook = do
           $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
               [ "errors" .=
                 [ "Need to be logged in as admin in order to access this page." :: Text ]
-              , "messages" .=
-                [ "<script>alert(1);</script>" :: Text ]
               ]
         Just adminSession -> do
             oldCtx <- getContext

--- a/src/Kucipong/Handler/Static.hs
+++ b/src/Kucipong/Handler/Static.hs
@@ -7,8 +7,8 @@ import           Kucipong.Prelude
 import           Language.Haskell.TH        (Exp, Q)
 import           Language.Haskell.TH.Syntax (addDependentFile, runIO)
 import           System.FilePath.Glob       (glob)
-import           System.FilePath.Posix      (takeFileName)
-import           Web.Spock                  (bytes, static)
+import           System.FilePath.Posix      (takeExtension, takeFileName)
+import           Web.Spock                  (bytes, setHeader, static)
 import           Web.Spock.Core             (get)
 
 staticComponent' :: Q Exp
@@ -22,12 +22,24 @@ staticComponent' = do
     -- setHeader "Content-Type" "text/html; charset=utf-8"
     [e| forM_ fileContents $ \(fp, content) ->
         get (static $ takeFileName fp) $
+          let
+            contentType = case takeExtension fp of
+                ".css" -> Just "text/css; charset=utf-8"
+                ".gif" -> Just "image/gif"
+                ".js" -> Just "application/javascript; charset=utf-8"
+                ".jpeg" -> Just "image/jpeg"
+                ".jpg" -> Just "image/jpeg"
+                ".png" -> Just "image/png"
+                ".svg" -> Just "image/svg+xml; charset=utf-8"
+                _ -> Nothing
+          in do
+            maybe (pure ()) (setHeader "Content-Type") contentType
             bytes $ encodeUtf8 content |]
   where
     handleFileContent :: FilePath -> IO Text -> IO (Maybe (FilePath, Text))
     handleFileContent fp a =
         catch (a >>= \v -> return (Just (fp, v))) $ \e -> do
-            fail $
+            void . fail $
                 "exception occured when trying to parse the static file \"" <>
                 fp <> ":\n" <> show (e :: SomeException)
             pure Nothing

--- a/src/Kucipong/Handler/Static.hs
+++ b/src/Kucipong/Handler/Static.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Kucipong.Handler.Static where
+
+import           Kucipong.Prelude
+import           Language.Haskell.TH        (Exp, Q)
+import           Language.Haskell.TH.Syntax (addDependentFile, runIO)
+import           System.FilePath.Glob       (glob)
+import           System.FilePath.Posix      (takeFileName)
+import           Web.Spock                  (bytes, static)
+import           Web.Spock.Core             (get)
+
+staticComponent' :: Q Exp
+staticComponent' = do
+    files <- runIO $ glob "frontend/dist/static/*"
+    mapM_ addDependentFile files
+    eitherFileContents <- forM files $ \fpath ->
+        liftIO . handleFileContent fpath . readFile $ fpath
+    let (x:fileContents) = catMaybes eitherFileContents
+    setStaticContent x
+  where
+    handleFileContent :: FilePath -> IO Text -> IO (Maybe (FilePath, Text))
+    handleFileContent fp a =
+        catch (a >>= \v -> return (Just (fp, v))) $ \e -> do
+            fail $
+                "exception occured when trying to parse the static file \"" <>
+                fp <> ":\n" <> show (e :: SomeException)
+            pure Nothing
+    setStaticContent :: (FilePath, Text) -> Q Exp
+    setStaticContent (fp, content) =
+        [e| get (static $ takeFileName fp) $ do
+            -- TODO Appropreate content type
+            -- setHeader "Content-Type" "text/html; charset=utf-8"
+            bytes $ encodeUtf8 content
+        |]

--- a/src/Kucipong/RenderTemplate.hs
+++ b/src/Kucipong/RenderTemplate.hs
@@ -8,13 +8,10 @@ import           Kucipong.Prelude           hiding (try)
 import           Control.Exception          (try)
 import           Control.FromSum            (fromEitherM)
 import qualified Data.HashMap.Strict        as HashMap
-import           Language.Haskell.TH        (Exp, Q, appE, litE,
-                                             lookupValueName, mkName, stringL,
-                                             varE)
+import           Language.Haskell.TH        (Exp, Q)
 import           Language.Haskell.TH.Syntax (addDependentFile)
 import           Network.HTTP.Types         (internalServerError500)
-import           Text.EDE                   (Template, eitherParse,
-                                             eitherRenderWith, fromPairs)
+import           Text.EDE                   (eitherParse, eitherRenderWith)
 import           Text.EDE.Filters           (Term, (@:))
 import           Web.Spock                  (html, setStatus)
 

--- a/src/Kucipong/RenderTemplate.hs
+++ b/src/Kucipong/RenderTemplate.hs
@@ -1,18 +1,22 @@
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE QuasiQuotes     #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Kucipong.RenderTemplate where
 
-import Kucipong.Prelude hiding ( try )
+import           Kucipong.Prelude           hiding (try)
 
-import Control.Exception ( try )
-import Control.FromSum ( fromEitherM )
-import Language.Haskell.TH
-    ( Exp, Q, appE, litE, lookupValueName, mkName, stringL, varE )
-import Language.Haskell.TH.Syntax ( addDependentFile )
-import Network.HTTP.Types ( internalServerError500 )
-import Text.EDE ( Template, eitherParse, eitherRender, fromPairs )
-import Web.Spock ( html, setStatus )
+import           Control.Exception          (try)
+import           Control.FromSum            (fromEitherM)
+import qualified Data.HashMap.Strict        as HashMap
+import           Language.Haskell.TH        (Exp, Q, appE, litE,
+                                             lookupValueName, mkName, stringL,
+                                             varE)
+import           Language.Haskell.TH.Syntax (addDependentFile)
+import           Network.HTTP.Types         (internalServerError500)
+import           Text.EDE                   (Template, eitherParse,
+                                             eitherRenderWith, fromPairs)
+import           Text.EDE.Filters           (Term, (@:))
+import           Web.Spock                  (html, setStatus)
 
 templateDirectory :: FilePath
 templateDirectory = "frontend" </> "dist"
@@ -32,7 +36,20 @@ renderTemplateFromEnv filename = do
     -- error during compile time to the user if it cannot.
     void $ fromEitherM handleIncorrectTemplate eitherParsedTemplate
     templateExp <- [e| unsafeFromRight $ eitherParse rawTemplate |]
-    eitherRenderLambdaExp <- [e| eitherRender $(pure templateExp) |]
+    eitherRenderLambdaExp <- [e|
+      let
+        escapeHtml :: Text -> Text
+        escapeHtml = concatMap $ \c -> case c of
+            '"' -> "&quot;"
+            '\'' -> "&#39;"
+            '&' -> "&amp;"
+            '<' -> "&lt;"
+            '>' -> "&gt;"
+            _ -> singleton c
+        filters :: HashMap Text Term
+        filters = HashMap.fromList [ "escape" @: escapeHtml ]
+      in
+        eitherRenderWith filters $(pure templateExp) |]
     [e| \environmentObject -> case $(pure eitherRenderLambdaExp) environmentObject of
             Left err -> do
                 setStatus internalServerError500


### PR DESCRIPTION
This PR is part of #13 .
The main changes are followings.
- Show messages to admin user on log in
  - After `make run`, access `http://localhost:8101/admin/store/create` to see the message
- Generate GET API for static files (js, css, svg for front-end) on compile time
- Add new filter for escaping characters to prevent XSS
- Make static files build in `dist/static`
- Add error message area

@cdepillabout please review.
