### PR TITLE
Remove outdated todo

### DIFF
--- a/src/Kucipong/Handler/Static/TH.hs
+++ b/src/Kucipong/Handler/Static/TH.hs
@@ -17,8 +17,6 @@ staticComponent' = do
     mapM_ addDependentFile files
     fileContents <- forM files $ \fpath ->
         liftIO . handleFileContent fpath . readFile $ fpath
-    -- TODO Appropreate content type
-    -- setHeader "Content-Type" "text/html; charset=utf-8"
     [e| forM_ fileContents $ \(fp, content) ->
         get (static $ takeFileName fp) $
           let

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -91,7 +91,6 @@ storeAuthHook = do
             oldCtx <- getContext
             return $ storeSession :&: oldCtx
 
--- TODO: It is better to make some module to share functions with admin handler.
 storeComponent
     :: forall m xs
      . ( MonadIO m

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -21,9 +21,6 @@ import Kucipong.Monad.SendEmail.Trans ( KucipongSendEmailT )
 -- Default implementations are used to easily derive instances for monads
 -- transformers that implement 'MonadTrans'.
 class Monad m => MonadKucipongDb m where
-    -- TODO
-    -- This is rough implementation.
-    -- Share functions with admin and store user.
 
     -- ===========
     --  For Admin


### PR DESCRIPTION
This PR resolves #30 .
TODO comments about sharing store and admin code is now out dated because we've divided tables about store user into two.

@cdepillabout , please review.
