### PR TITLE
Change the type of `getReqParam` to return `Either`

### DIFF
--- a/src/Kucipong/Handler.hs
+++ b/src/Kucipong/Handler.hs
@@ -4,34 +4,36 @@ module Kucipong.Handler where
 
 import Kucipong.Prelude
 
-import Data.HVect ( HVect(HNil) )
-import Network.Wai ( Middleware )
-import Web.Spock ( ActionCtxT, html , root, runSpock )
-import Web.Spock.Core ( spockT, get, prehook, subcomponent )
+import Data.HVect (HVect(HNil))
+import Network.Wai (Middleware)
+import Web.Spock (ActionCtxT, html, root, runSpock)
+import Web.Spock.Core (spockT, get, prehook, subcomponent)
 
-import Kucipong.Config ( Config )
-import Kucipong.Handler.Admin ( adminComponent, adminUrlPrefix )
-import Kucipong.Handler.Store ( storeComponent, storeUrlPrefix )
-import Kucipong.Handler.Static ( staticComponent, staticUrlPrefix )
-import Kucipong.Host ( HasPort(..) )
-import Kucipong.Monad ( KucipongM, runKucipongM )
+import Kucipong.Config (Config)
+import Kucipong.Handler.Admin (adminComponent, adminUrlPrefix)
+import Kucipong.Handler.Static (staticComponent, staticUrlPrefix)
+import Kucipong.Handler.Store (storeComponent, storeUrlPrefix)
+import Kucipong.Host (HasPort(..))
+import Kucipong.Monad (KucipongM, runKucipongM)
 
 runKucipongMHandleErrors :: Config -> KucipongM a -> IO a
 runKucipongMHandleErrors config = either throwIO pure <=< runKucipongM config
 
-baseHook :: Monad m => ActionCtxT () m (HVect '[])
+baseHook
+  :: Monad m
+  => ActionCtxT () m (HVect '[])
 baseHook = pure HNil
 
 app :: Middleware -> Config -> IO ()
 app middleware config = do
-    spockMiddleware <- spockMiddlewareIO
-    runSpock (getPort config) . pure $ middleware . spockMiddleware
+  spockMiddleware <- spockMiddlewareIO
+  runSpock (getPort config) . pure $ middleware . spockMiddleware
   where
     spockMiddlewareIO :: IO Middleware
     spockMiddlewareIO =
-        spockT (runKucipongMHandleErrors config) $ do
-            subcomponent staticUrlPrefix staticComponent
-            prehook baseHook $ do
-                subcomponent adminUrlPrefix adminComponent
-                subcomponent storeUrlPrefix storeComponent
-            get root $ do html "<p>hello world</p>"
+      spockT (runKucipongMHandleErrors config) $ do
+        subcomponent staticUrlPrefix staticComponent
+        prehook baseHook $ do
+          subcomponent adminUrlPrefix adminComponent
+          subcomponent storeUrlPrefix storeComponent
+        get root $ do html "<p>hello world</p>"

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -4,31 +4,33 @@ module Kucipong.Handler.Admin where
 
 import Kucipong.Prelude
 
-import Control.FromSum ( fromMaybeM )
-import Control.Monad.Time ( MonadTime(..) )
-import Data.Aeson ( (.=) )
-import Data.HVect ( HVect(..) )
-import Database.Persist ( Entity(..) )
-import Network.HTTP.Types ( forbidden403 )
-import Text.EDE ( fromPairs )
-import Web.Routing.Combinators ( PathState(Open) )
+import Control.FromSum (fromMaybeM)
+import Control.Monad.Time (MonadTime(..))
+import Data.Aeson ((.=))
+import Data.HVect (HVect(..))
+import Database.Persist (Entity(..))
+import Network.HTTP.Types (forbidden403)
+import Text.EDE (fromPairs)
+import Web.Routing.Combinators (PathState(Open))
 import Web.Spock
-    ( ActionCtxT, Path, (<//>), getContext, root, redirect, renderRoute
-    , setStatus, var )
-import Web.Spock.Core ( SpockCtxT, get, post, prehook )
+       (ActionCtxT, Path, (<//>), getContext, root, redirect, renderRoute,
+        setStatus, var)
+import Web.Spock.Core (SpockCtxT, get, post, prehook)
 
 import Kucipong.Db
-    ( Key(..), LoginTokenExpirationTime(..), adminLoginTokenExpirationTime
-    , storeEmailEmail, storeLoginTokenLoginToken )
-import Kucipong.Form ( AdminStoreCreateForm(AdminStoreCreateForm) )
-import Kucipong.LoginToken ( LoginToken )
+       (Key(..), LoginTokenExpirationTime(..),
+        adminLoginTokenExpirationTime, storeEmailEmail,
+        storeLoginTokenLoginToken)
+import Kucipong.Form (AdminStoreCreateForm(AdminStoreCreateForm))
+import Kucipong.LoginToken (LoginToken)
 import Kucipong.Monad
-    ( MonadKucipongCookie, MonadKucipongDb(..), MonadKucipongSendEmail(..) )
-import Kucipong.RenderTemplate ( renderTemplateFromEnv )
+       (MonadKucipongCookie, MonadKucipongDb(..),
+        MonadKucipongSendEmail(..))
+import Kucipong.RenderTemplate (renderTemplateFromEnv)
+import Kucipong.Session (Admin, Session(..))
 import Kucipong.Spock
-    ( ContainsAdminSession, getAdminCookie, getAdminEmail, getReqParamErr
-    , setAdminCookie )
-import Kucipong.Session ( Admin, Session(..) )
+       (ContainsAdminSession, getAdminCookie, getAdminEmail,
+        getReqParamErr, setAdminCookie)
 
 -- | Url prefix for all of the following 'Path's.
 adminUrlPrefix :: Path '[] 'Open
@@ -44,78 +46,66 @@ storeCreateR :: Path '[] 'Open
 storeCreateR = "store" <//> "create"
 
 loginGet
-    :: forall ctx m
-     . ( MonadIO m
-       )
-    => ActionCtxT ctx m ()
+  :: forall ctx m.
+     (MonadIO m)
+  => ActionCtxT ctx m ()
 loginGet = $(renderTemplateFromEnv "adminUser_login.html") mempty
 
 -- | Login an admin.  Take the admin's 'LoginToken', and send them a session
 -- cookie.
 doLoginGet
-    :: forall ctx m
-     . ( MonadIO m
-       , MonadKucipongCookie m
-       , MonadKucipongDb m
-       , MonadTime m
-       )
-    => LoginToken -> ActionCtxT ctx m ()
+  :: forall ctx m.
+     (MonadIO m, MonadKucipongCookie m, MonadKucipongDb m, MonadTime m)
+  => LoginToken -> ActionCtxT ctx m ()
 doLoginGet loginToken = do
-    maybeAdminLoginTokenEntity <- dbFindAdminLoginToken loginToken
-    (Entity (AdminLoginTokenKey (AdminKey adminEmail)) adminLoginToken) <-
-        fromMaybeM noAdminLoginTokenError maybeAdminLoginTokenEntity
+  maybeAdminLoginTokenEntity <- dbFindAdminLoginToken loginToken
+  (Entity (AdminLoginTokenKey (AdminKey adminEmail)) adminLoginToken) <-
+    fromMaybeM noAdminLoginTokenError maybeAdminLoginTokenEntity
     -- check date on admin login token
-    now <- currentTime
-    let (LoginTokenExpirationTime expirationTime) =
-            adminLoginTokenExpirationTime adminLoginToken
-    when (now > expirationTime) tokenExpiredError
-    setAdminCookie adminEmail
-    redirect $ renderRoute root
+  now <- currentTime
+  let (LoginTokenExpirationTime expirationTime) =
+        adminLoginTokenExpirationTime adminLoginToken
+  when (now > expirationTime) tokenExpiredError
+  setAdminCookie adminEmail
+  redirect $ renderRoute root
   where
     noAdminLoginTokenError :: ActionCtxT ctx m a
     noAdminLoginTokenError = do
-        setStatus forbidden403
-        $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
-            [ "errors" .=
-              [ "Failed to log in X(\nPlease try again." :: Text ]
-            ]
-
+      setStatus forbidden403
+      $(renderTemplateFromEnv "adminUser_login.html") $
+        fromPairs
+          ["errors" .= ["Failed to log in X(\nPlease try again." :: Text]]
     tokenExpiredError :: ActionCtxT ctx m a
     tokenExpiredError = do
-        setStatus forbidden403
-        $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
-            [ "errors" .=
-              [ "This log in URL has been expired X(\nPlease try again." :: Text ]
-            ]
+      setStatus forbidden403
+      $(renderTemplateFromEnv "adminUser_login.html") $
+        fromPairs
+          [ "errors" .=
+            ["This log in URL has been expired X(\nPlease try again." :: Text]
+          ]
 
 -- | Return the store create page for an admin.
 storeCreateGet
-    :: forall xs n m
-     . ( ContainsAdminSession n xs
-       , MonadIO m
-       )
-    => ActionCtxT (HVect xs) m ()
+  :: forall xs n m.
+     (ContainsAdminSession n xs, MonadIO m)
+  => ActionCtxT (HVect xs) m ()
 storeCreateGet = do
-    (AdminSession email) <- getAdminEmail
-    $(renderTemplateFromEnv "adminUser_admin_store_create.html") $ fromPairs
-        [ "adminEmail" .= email ]
+  (AdminSession email) <- getAdminEmail
+  $(renderTemplateFromEnv "adminUser_admin_store_create.html") $
+    fromPairs ["adminEmail" .= email]
 
 storeCreatePost
-    :: forall xs m
-     . ( MonadIO m
-       , MonadKucipongDb m
-       , MonadKucipongSendEmail m
-       )
-    => ActionCtxT (HVect xs) m ()
+  :: forall xs m.
+     (MonadIO m, MonadKucipongDb m, MonadKucipongSendEmail m)
+  => ActionCtxT (HVect xs) m ()
 storeCreatePost = do
-    (AdminStoreCreateForm storeEmailParam) <- getReqParamErr handleErr
-    (Entity storeEmailKey storeEmail) <- dbCreateStoreEmail storeEmailParam
-    (Entity _ storeLoginToken) <-
-        dbCreateStoreMagicLoginToken storeEmailKey
-    sendStoreLoginEmail
-        (storeEmailEmail storeEmail)
-        (storeLoginTokenLoginToken storeLoginToken)
-    redirect . renderRoute $ adminUrlPrefix <//> storeCreateR
+  (AdminStoreCreateForm storeEmailParam) <- getReqParamErr handleErr
+  (Entity storeEmailKey storeEmail) <- dbCreateStoreEmail storeEmailParam
+  (Entity _ storeLoginToken) <- dbCreateStoreMagicLoginToken storeEmailKey
+  sendStoreLoginEmail
+    (storeEmailEmail storeEmail)
+    (storeLoginTokenLoginToken storeLoginToken)
+  redirect . renderRoute $ adminUrlPrefix <//> storeCreateR
   where
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg =
@@ -123,34 +113,34 @@ storeCreatePost = do
       fromPairs ["errors" .= [errMsg]]
 
 adminAuthHook
-    :: ( MonadIO m
-       , MonadKucipongCookie m
-       )
-    => ActionCtxT (HVect xs) m (HVect ((Session Kucipong.Session.Admin) ': xs))
+  :: (MonadIO m, MonadKucipongCookie m)
+  => ActionCtxT (HVect xs) m (HVect ((Session Kucipong.Session.Admin) ': xs))
 adminAuthHook = do
-    maybeAdminSession <- getAdminCookie
-    case maybeAdminSession of
-        Nothing ->
-          $(renderTemplateFromEnv "adminUser_login.html") $ fromPairs
-              [ "errors" .=
-                [ "Need to be logged in as admin in order to access this page." :: Text ]
-              ]
-        Just adminSession -> do
-            oldCtx <- getContext
-            return $ adminSession :&: oldCtx
+  maybeAdminSession <- getAdminCookie
+  case maybeAdminSession of
+    Nothing ->
+      $(renderTemplateFromEnv "adminUser_login.html") $
+      fromPairs
+        [ "errors" .=
+          [ "Need to be logged in as admin in order to access this page." :: Text
+          ]
+        ]
+    Just adminSession -> do
+      oldCtx <- getContext
+      return $ adminSession :&: oldCtx
 
 adminComponent
-    :: forall m xs
-     . ( MonadIO m
-       , MonadKucipongCookie m
-       , MonadKucipongDb m
-       , MonadKucipongSendEmail m
-       , MonadTime m
-       )
-    => SpockCtxT (HVect xs) m ()
+  :: forall m xs.
+     ( MonadIO m
+     , MonadKucipongCookie m
+     , MonadKucipongDb m
+     , MonadKucipongSendEmail m
+     , MonadTime m
+     )
+  => SpockCtxT (HVect xs) m ()
 adminComponent = do
-    get doLoginR doLoginGet
-    get loginR loginGet
-    prehook adminAuthHook $ do
-        get storeCreateR storeCreateGet
-        post storeCreateR storeCreatePost
+  get doLoginR doLoginGet
+  get loginR loginGet
+  prehook adminAuthHook $ do
+    get storeCreateR storeCreateGet
+    post storeCreateR storeCreatePost

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -4,27 +4,25 @@ module Kucipong.Handler.Store where
 
 import Kucipong.Prelude
 
-import Control.FromSum ( fromMaybeM )
-import Control.Monad.Time ( MonadTime(..) )
-import Data.HVect ( HVect(..) )
-import Database.Persist ( Entity(..) )
-import Text.EDE ( fromPairs )
-import Web.Routing.Combinators ( PathState(Open) )
+import Control.FromSum (fromMaybeM)
+import Control.Monad.Time (MonadTime(..))
+import Data.HVect (HVect(..))
+import Database.Persist (Entity(..))
+import Text.EDE (fromPairs)
+import Web.Routing.Combinators (PathState(Open))
 import Web.Spock
-    ( ActionCtxT, Path, (<//>), getContext
-    , root, redirect, renderRoute, var )
-import Web.Spock.Core ( SpockCtxT, get )
+       (ActionCtxT, Path, (<//>), getContext, root, redirect, renderRoute,
+        var)
+import Web.Spock.Core (SpockCtxT, get)
 
 import Kucipong.Db
-    ( Key(..), LoginTokenExpirationTime(..)
-    , storeLoginTokenExpirationTime )
-import Kucipong.LoginToken ( LoginToken )
-import Kucipong.Monad
-    ( MonadKucipongCookie, MonadKucipongDb(..) )
-import Kucipong.RenderTemplate ( renderTemplateFromEnv )
-import Kucipong.Spock
-    ( getStoreCookie, setStoreCookie )
-import Kucipong.Session ( Store, Session(..) )
+       (Key(..), LoginTokenExpirationTime(..),
+        storeLoginTokenExpirationTime)
+import Kucipong.LoginToken (LoginToken)
+import Kucipong.Monad (MonadKucipongCookie, MonadKucipongDb(..))
+import Kucipong.RenderTemplate (renderTemplateFromEnv)
+import Kucipong.Session (Store, Session(..))
+import Kucipong.Spock (getStoreCookie, setStoreCookie)
 
 -- | Url prefix for all of the following 'Path's.
 storeUrlPrefix :: Path '[] 'Open
@@ -37,67 +35,52 @@ doLoginR :: Path '[LoginToken] 'Open
 doLoginR = loginPageR <//> var
 
 loginPage
-    :: forall ctx m
-     . ( MonadIO m
-       )
-    => ActionCtxT ctx m ()
-loginPage =
-    $(renderTemplateFromEnv "storeUser_login.html") $ fromPairs []
+  :: forall ctx m.
+     (MonadIO m)
+  => ActionCtxT ctx m ()
+loginPage = $(renderTemplateFromEnv "storeUser_login.html") $ fromPairs []
 
 -- | Login an store.  Take the store's 'LoginToken', and send them a session
 -- cookie.
 doLogin
-    :: forall ctx m
-     . ( MonadIO m
-       , MonadKucipongCookie m
-       , MonadKucipongDb m
-       , MonadTime m
-       )
-    => LoginToken -> ActionCtxT ctx m ()
+  :: forall ctx m.
+     (MonadIO m, MonadKucipongCookie m, MonadKucipongDb m, MonadTime m)
+  => LoginToken -> ActionCtxT ctx m ()
 doLogin loginToken = do
-    maybeStoreLoginTokenEntity <- dbFindStoreLoginToken loginToken
-    (Entity (StoreLoginTokenKey (StoreEmailKey storeEmail)) storeLoginToken) <-
-        fromMaybeM noStoreLoginTokenError maybeStoreLoginTokenEntity
+  maybeStoreLoginTokenEntity <- dbFindStoreLoginToken loginToken
+  (Entity (StoreLoginTokenKey (StoreEmailKey storeEmail)) storeLoginToken) <-
+    fromMaybeM noStoreLoginTokenError maybeStoreLoginTokenEntity
     -- check date on store login token
-    now <- currentTime
-    let (LoginTokenExpirationTime expirationTime) =
-            storeLoginTokenExpirationTime storeLoginToken
-    when (now > expirationTime) tokenExpiredError
-    setStoreCookie storeEmail
-    redirect $ renderRoute root
+  now <- currentTime
+  let (LoginTokenExpirationTime expirationTime) =
+        storeLoginTokenExpirationTime storeLoginToken
+  when (now > expirationTime) tokenExpiredError
+  setStoreCookie storeEmail
+  redirect $ renderRoute root
   where
     noStoreLoginTokenError :: ActionCtxT ctx m a
     noStoreLoginTokenError =
-        redirect . renderRoute $ storeUrlPrefix <//> loginPageR
-
+      redirect . renderRoute $ storeUrlPrefix <//> loginPageR
     tokenExpiredError :: ActionCtxT ctx m a
-    tokenExpiredError =
-        redirect . renderRoute $ storeUrlPrefix <//> loginPageR
+    tokenExpiredError = redirect . renderRoute $ storeUrlPrefix <//> loginPageR
 
 storeAuthHook
-    :: ( MonadIO m
-       , MonadKucipongCookie m
-       )
-    => ActionCtxT (HVect xs) m (HVect ((Session Kucipong.Session.Store) ': xs))
+  :: (MonadIO m, MonadKucipongCookie m)
+  => ActionCtxT (HVect xs) m (HVect ((Session Kucipong.Session.Store) ': xs))
 storeAuthHook = do
-    maybeStoreSession <- getStoreCookie
-    case maybeStoreSession of
-        Nothing ->
-            redirect . renderRoute $ storeUrlPrefix <//> loginPageR
-        Just storeSession -> do
-            oldCtx <- getContext
-            return $ storeSession :&: oldCtx
+  maybeStoreSession <- getStoreCookie
+  case maybeStoreSession of
+    Nothing -> redirect . renderRoute $ storeUrlPrefix <//> loginPageR
+    Just storeSession -> do
+      oldCtx <- getContext
+      return $ storeSession :&: oldCtx
 
 storeComponent
-    :: forall m xs
-     . ( MonadIO m
-       , MonadKucipongCookie m
-       , MonadKucipongDb m
-       , MonadTime m
-       )
-    => SpockCtxT (HVect xs) m ()
+  :: forall m xs.
+     (MonadIO m, MonadKucipongCookie m, MonadKucipongDb m, MonadTime m)
+  => SpockCtxT (HVect xs) m ()
 storeComponent = do
-    get doLoginR doLogin
-    get loginPageR loginPage
+  get doLoginR doLogin
+  get loginPageR loginPage
     -- prehook storeAuthHook $
     --     get ("store" <//> "something") someAction


### PR DESCRIPTION
This PR changes the type of `getReqParam` to return `Either` in commit 4e16567.  It also modifies `Kucipong.Handler.Admin` to use `getReqParamErr`.

Commit a390817 reformats the `Kucipong.Handler.Admin` module with `hindent`.
Commit 6b384a9 reformats the `Kucipong.Handler.Store` module with `hindent`.
Commit 238924e reformats the `Kucipong.Handler` module with `hindent`.
@arowM Please review.
