### PR TITLE
add Admin login POST handler

### DIFF
--- a/src/Kucipong/Email.hs
+++ b/src/Kucipong/Email.hs
@@ -82,7 +82,7 @@ adminLoginMsg
 adminLoginMsg protocol host adminEmail loginToken = do
     let loginTokenText =
             asText $ pack $ urlEncode $ unpack $ unLoginToken loginToken
-        subject = "Kucipong Store Login"
+        subject = "Kucipong Admin Login"
         content = TextOnly . encodeUtf8 $ textContent loginTokenText
         replyTo = "no-reply@kucipong.com"
         to = toByteString adminEmail
@@ -94,9 +94,9 @@ adminLoginMsg protocol host adminEmail loginToken = do
     textContent loginTokenText =
         [st|
 This is an email from Kucipong.  You can use the following URL to
-login as a Store:
+login as an admin:
 
-#{protocol}://#{host}/store/login/#{loginTokenText}
+#{protocol}://#{host}/admin/login/#{loginTokenText}
         |]
 
 sendStoreLoginEmail

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -9,11 +9,10 @@ module Kucipong.Form where
 
 import Kucipong.Prelude
 
-import Web.FormUrlEncoded ( FromForm )
+import Web.FormUrlEncoded (FromForm)
 
-data AdminStoreCreateForm =
-    AdminStoreCreateForm
-        { storeEmail :: EmailAddress }
-    deriving (Data, Eq, Generic, Show, Typeable)
+data AdminStoreCreateForm = AdminStoreCreateForm
+  { storeEmail :: EmailAddress
+  } deriving (Data, Eq, Generic, Show, Typeable)
 
 instance FromForm AdminStoreCreateForm

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -11,6 +11,12 @@ import Kucipong.Prelude
 
 import Web.FormUrlEncoded (FromForm)
 
+data AdminLoginForm = AdminLoginForm
+  { email :: EmailAddress
+  } deriving (Data, Eq, Generic, Show, Typeable)
+
+instance FromForm AdminLoginForm
+
 data AdminStoreCreateForm = AdminStoreCreateForm
   { storeEmail :: EmailAddress
   } deriving (Data, Eq, Generic, Show, Typeable)

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -48,6 +48,15 @@ class Monad m => MonadKucipongDb m where
         => Key Admin -> t n (Entity AdminLoginToken)
     dbCreateAdminMagicLoginToken = lift . dbCreateAdminMagicLoginToken
 
+    dbFindAdmin :: EmailAddress -> m (Maybe (Entity Admin))
+    default dbFindAdmin
+        :: ( MonadKucipongDb n
+           , MonadTrans t
+           , m ~ t n
+           )
+        => EmailAddress -> t n (Maybe (Entity Admin))
+    dbFindAdmin = lift . dbFindAdmin
+
     dbFindAdminLoginToken :: LoginToken -> m (Maybe (Entity AdminLoginToken))
     default dbFindAdminLoginToken
         :: ( MonadKucipongDb n

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -65,6 +65,18 @@ instance ( MonadBaseControl IO m
         go :: m (Maybe (Entity AdminLoginToken))
         go = runDb $ selectFirst [AdminLoginTokenLoginToken ==. loginToken] []
 
+    dbFindAdmin :: EmailAddress -> KucipongDbT m (Maybe (Entity Admin))
+    dbFindAdmin email = lift go
+      where
+        go :: m (Maybe (Entity Admin))
+        go = fmap (fmap createEntity) . runDb $ get adminKey
+
+        createEntity :: Admin -> Entity Admin
+        createEntity = Entity adminKey
+
+        adminKey :: Key Admin
+        adminKey = AdminKey email
+
     dbUpsertAdmin :: EmailAddress -> Text -> KucipongDbT m (Entity Admin)
     dbUpsertAdmin email name = lift go
       where


### PR DESCRIPTION
This PR adds a login POST handler for the Admin user.  The only interesting code is in commit 358cfd4.

This functionality is for the ["Request User Verification"](https://github.com/blueimpact/kucipong/blob/master/doc/api.md#request-user-verification--user-verification) handler for the Admin user.  However, the handler url in the documentation is slightly different what this PR is using.  Should I edit the documentation?
