### PR TITLE
Add handlers for store login.

### DIFF
--- a/frontend/src/pug/storeUser_login.pug
+++ b/frontend/src/pug/storeUser_login.pug
@@ -5,6 +5,8 @@ include _layout
     include _messageArea
     .store
       form#js-request-verification.loginSignboard(
+        action="/store/login"
+        method="POST"
         data-user-type="store"
       )
         .loginSignboard_titleArea

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -35,3 +35,9 @@ data AdminStoreDeleteForm = AdminStoreDeleteForm
   } deriving (Data, Eq, Generic, Show, Typeable)
 
 instance FromForm AdminStoreDeleteForm
+
+data StoreLoginForm = StoreLoginForm
+  { email :: EmailAddress
+  } deriving (Data, Eq, Generic, Show, Typeable)
+
+instance FromForm StoreLoginForm

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -6,6 +6,7 @@ import Kucipong.Prelude
 
 import Control.FromSum (fromMaybeM)
 import Control.Monad.Time (MonadTime(..))
+import Data.Aeson ((.=))
 import Data.HVect (HVect(..))
 import Database.Persist (Entity(..))
 import Text.EDE (fromPairs)
@@ -13,34 +14,72 @@ import Web.Routing.Combinators (PathState(Open))
 import Web.Spock
        (ActionCtxT, Path, (<//>), getContext, root, redirect, renderRoute,
         var)
-import Web.Spock.Core (SpockCtxT, get)
+import Web.Spock.Core (SpockCtxT, get, post)
 
 import Kucipong.Db
        (Key(..), LoginTokenExpirationTime(..),
-        StoreLoginToken(storeLoginTokenExpirationTime))
+        StoreLoginToken(storeLoginTokenExpirationTime,
+                        storeLoginTokenLoginToken))
+import Kucipong.Email (EmailError)
+import Kucipong.Form (StoreLoginForm(StoreLoginForm))
 import Kucipong.LoginToken (LoginToken)
 import Kucipong.Monad
-       (MonadKucipongCookie, MonadKucipongDb(..), dbFindStoreLoginToken)
+       (MonadKucipongCookie, MonadKucipongDb(..),
+        MonadKucipongSendEmail(..), dbFindStoreByEmail, dbFindStoreLoginToken)
 import Kucipong.RenderTemplate (renderTemplateFromEnv)
 import Kucipong.Session (Store, Session(..))
-import Kucipong.Spock (getStoreCookie, setStoreCookie)
+import Kucipong.Spock (getReqParamErr, getStoreCookie, setStoreCookie)
 
 -- | Url prefix for all of the following 'Path's.
 storeUrlPrefix :: Path '[] 'Open
 storeUrlPrefix = "store"
 
-loginPageR :: Path '[] 'Open
-loginPageR = "login"
+rootR :: Path '[] 'Open
+rootR = ""
+
+loginR :: Path '[] 'Open
+loginR = "login"
 
 doLoginR :: Path '[LoginToken] 'Open
-doLoginR = loginPageR <//> var
+doLoginR = loginR <//> var
 
 -- | Handler for returning the store login page.
-loginPage
+loginGet
   :: forall ctx m.
      (MonadIO m)
   => ActionCtxT ctx m ()
-loginPage = $(renderTemplateFromEnv "storeUser_login.html") $ fromPairs []
+loginGet = $(renderTemplateFromEnv "storeUser_login.html") $ fromPairs []
+
+-- | Handler for sending an email to the store owner that they can use to
+-- login.
+loginPost
+  :: forall xs m.
+     (MonadIO m, MonadKucipongDb m, MonadKucipongSendEmail m, MonadLogger m)
+  => ActionCtxT (HVect xs) m ()
+loginPost = do
+  (StoreLoginForm email) <- getReqParamErr handleErr
+  maybeStoreEntity <- dbFindStoreByEmail email
+  (Entity (StoreKey storeEmailKey) _) <-
+    fromMaybeM
+      (handleErr $ "Could not find store for email " <> tshow email)
+      maybeStoreEntity
+  (Entity _ storeLoginToken) <- dbCreateStoreMagicLoginToken storeEmailKey
+  maybe (pure ()) handleSendEmailFail =<<
+    sendStoreLoginEmail email (storeLoginTokenLoginToken storeLoginToken)
+  $(renderTemplateFromEnv "storeUser_login.html") $
+    fromPairs
+      ["messages" .= ["We have sent you an email with verification URL." :: Text]]
+  where
+    handleErr :: Text -> ActionCtxT (HVect xs) m a
+    handleErr errMsg = do
+      $(logDebug) $ "got following error in store loginPost handler: " <> errMsg
+      $(renderTemplateFromEnv "storeUser_login.html") $
+        fromPairs ["errors" .= [errMsg]]
+
+    handleSendEmailFail :: EmailError -> ActionCtxT (HVect xs) m a
+    handleSendEmailFail emailError = do
+      $(logDebug) $ "got email error in store loginPost: " <> tshow emailError
+      handleErr "could not send email"
 
 -- | Login an store.  Take the store's 'LoginToken', and send them a session
 -- cookie.
@@ -62,9 +101,9 @@ doLogin loginToken = do
   where
     noStoreLoginTokenError :: ActionCtxT ctx m a
     noStoreLoginTokenError =
-      redirect . renderRoute $ storeUrlPrefix <//> loginPageR
+      redirect . renderRoute $ storeUrlPrefix <//> loginR
     tokenExpiredError :: ActionCtxT ctx m a
-    tokenExpiredError = redirect . renderRoute $ storeUrlPrefix <//> loginPageR
+    tokenExpiredError = redirect . renderRoute $ storeUrlPrefix <//> loginR
 
 storeAuthHook
   :: (MonadIO m, MonadKucipongCookie m)
@@ -72,17 +111,24 @@ storeAuthHook
 storeAuthHook = do
   maybeStoreSession <- getStoreCookie
   case maybeStoreSession of
-    Nothing -> redirect . renderRoute $ storeUrlPrefix <//> loginPageR
+    Nothing -> redirect . renderRoute $ storeUrlPrefix <//> loginR
     Just storeSession -> do
       oldCtx <- getContext
       return $ storeSession :&: oldCtx
 
 storeComponent
   :: forall m xs.
-     (MonadIO m, MonadKucipongCookie m, MonadKucipongDb m, MonadTime m)
+     ( MonadIO m
+     , MonadKucipongCookie m
+     , MonadKucipongDb m
+     , MonadKucipongSendEmail m
+     , MonadLogger m
+     , MonadTime m
+     )
   => SpockCtxT (HVect xs) m ()
 storeComponent = do
   get doLoginR doLogin
-  get loginPageR loginPage
+  get loginR loginGet
+  post loginR loginPost
     -- prehook storeAuthHook $
     --     get ("store" <//> "something") someAction


### PR DESCRIPTION
Commit e42ff56 adds the handlers for POSTing an email address to /store/login and then for sending the user an email, and for actually doing the login and setting the cookie for the store user.

Commit 4a83e23 modifies the frontend code to actually POST the email address to /store/login.

Closes #48.