### PR TITLE
Bump the emailaddress package version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,5 @@ script:
   npm run build
   cd ../
   # TODO: haddock fails with ghc-8.0.1.  Reenable haddock when we get lts-8.
-  stack --no-terminal build --bench --no-run-benchmarks # --haddock --no-haddock-deps
+  stack --no-terminal test --bench --no-run-benchmarks # --haddock --no-haddock-deps
   set +ex
-# TODO: The doc tests take a really long time to run.
-# Fix this so we don't have to worry about timeouts?
-#- travis_wait 50 stack --no-terminal test --bench --no-run-benchmarks --haddock --no-haddock-deps

--- a/app/AddAdmin.hs
+++ b/app/AddAdmin.hs
@@ -9,7 +9,7 @@ import Options.Applicative
     ( InfoMod, Parser, ParserInfo, ReadM, argument, eitherReader, execParser
     , fullDesc, header, helper, info, metavar, progDesc, str
     )
-import Text.Email.Validate ( validateFromString )
+import Text.EmailAddress ( validateFromString )
 
 import Kucipong.Config ( createConfigFromEnv )
 import Kucipong.Db ( AdminLoginToken(adminLoginTokenLoginToken) )

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -132,7 +132,6 @@ library
                      , NoImplicitPrelude
                      , NoMonomorphismRestriction
                      , OverloadedStrings
-                     , PackageImports
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards
@@ -170,7 +169,6 @@ executable kucipong
                      , NoImplicitPrelude
                      , NoMonomorphismRestriction
                      , OverloadedStrings
-                     , PackageImports
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards

--- a/src/Kucipong/Email.hs
+++ b/src/Kucipong/Email.hs
@@ -9,7 +9,7 @@ import Mail.Hailgun
     , HailgunMessage, HailgunSendResponse, MessageContent(..)
     , MessageRecipients(..), emptyMessageRecipients, hailgunMessage, sendEmail )
 import Network.HTTP.Base ( urlEncode )
-import "emailaddress" Text.Email.Validate ( toByteString )
+import Text.EmailAddress ( toByteString )
 import Text.Shakespeare.Text ( st )
 
 import Kucipong.Host

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -9,7 +9,7 @@ import Control.Monad.Time (MonadTime(..))
 import Data.HVect (HVect(..))
 import Database.Persist (Entity(..))
 import Network.HTTP.Types (forbidden403)
-import Text.Email.Validate (toText)
+import Text.EmailAddress (toText)
 import Web.Routing.Combinators (PathState(Open))
 import Web.Spock
        (ActionCtxT, Path, (<//>), getContext, redirect, renderRoute,

--- a/src/Kucipong/Prelude.hs
+++ b/src/Kucipong/Prelude.hs
@@ -12,7 +12,7 @@ import Control.Monad.Trans.Identity as X ( IdentityT(..), runIdentityT )
 import Data.Data as X ( Data )
 import Data.Proxy as X ( Proxy(Proxy) )
 import Data.Word as X ( Word16 )
-import "emailaddress" Text.Email.Validate as X ( EmailAddress )
+import Text.EmailAddress as X ( EmailAddress )
 
 -- Orphan instances
 

--- a/src/Kucipong/Session.hs
+++ b/src/Kucipong/Session.hs
@@ -15,7 +15,7 @@ module Kucipong.Session
 
 import Kucipong.Prelude
 
-import "emailaddress" Text.Email.Validate ( emailAddress, toByteString )
+import Text.EmailAddress ( emailAddress, toByteString )
 import Web.ClientSession ( Key, decrypt, encryptIO )
 
 class HasSessionKey r where

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,9 +12,12 @@ packages:
 extra-deps:
     # This should be available in lts-8.
     - http-api-data-0.3.1
-    # This should be available in lts-7.3.
+    # This should be available in lts-8.
     - from-sum-0.1.2.0
+    # This should be available in lts-8.
     - heterocephalus-1.0.1.0
+    # This should be available in lts-8.
+    - emailaddress-0.2.0.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -34,7 +34,6 @@ ghcExtensions =
     , "-XNoImplicitPrelude"
     , "-XNoMonomorphismRestriction"
     , "-XOverloadedStrings"
-    , "-XPackageImports"
     , "-XPolyKinds"
     , "-XRankNTypes"
     , "-XRecordWildCards"


### PR DESCRIPTION
Bumping the emailaddress package version makes it so we don't have to use
the PackageImports language pragma anymore.