### PR TITLE
I18n for admin pages

### DIFF
--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -69,6 +69,7 @@ library
                      , blaze-markup
                      , classy-prelude
                      , clientsession
+                     , data-default
                      , emailaddress
                      , envelope
                      , from-sum

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -30,6 +30,7 @@ library
                      , Kucipong.Form
                      , Kucipong.Handler
                      , Kucipong.Handler.Admin
+                     , Kucipong.Handler.Admin.Types
                      , Kucipong.Handler.Store
                      , Kucipong.Handler.Static
                      , Kucipong.Handler.Static.TH

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -87,8 +87,7 @@ loginPost = do
   (Entity _ adminLoginToken) <- dbCreateAdminMagicLoginToken adminKey
   maybe (pure ()) handleSendEmailFail =<<
     sendAdminLoginEmail email (adminLoginTokenLoginToken adminLoginToken)
-  let
-    messages = [label def AdminMsgSentVerificationEmail]
+  let messages = [label def AdminMsgSentVerificationEmail]
   $(renderTemplateFromEnv "adminUser_login.html")
   where
     handleErr :: Text -> ActionCtxT (HVect xs) m a
@@ -96,7 +95,6 @@ loginPost = do
       $(logDebug) $ "got following error in admin loginPost handler: " <> errMsg
       let errors = [errMsg]
       $(renderTemplateFromEnv "adminUser_login.html")
-
     handleSendEmailFail :: EmailError -> ActionCtxT (HVect xs) m a
     handleSendEmailFail emailError = do
       $(logDebug) $ "got email error in admin loginPost: " <> tshow emailError
@@ -162,12 +160,11 @@ storeCreatePost = do
         "got following error in admin storeCreatePost handler: " <> errMsg
       let errors = [errMsg]
       $(renderTemplateFromEnv "adminUser_admin_store_create.html")
-
     handleCreateStoreFail :: DbSafeError -> ActionCtxT (HVect xs) m a
     handleCreateStoreFail DbSafeUniquenessViolation =
       handleErr $ label def AdminErrorStoreWithSameEmailExists
-    handleCreateStoreFail _ = handleErr $ label def AdminErrorStoreCreateDbProblem
-
+    handleCreateStoreFail _ =
+      handleErr $ label def AdminErrorStoreCreateDbProblem
     handleSendEmailFail :: EmailError -> ActionCtxT (HVect xs) m a
     handleSendEmailFail emailError = do
       $(logDebug) $
@@ -179,8 +176,7 @@ storeDeleteGet
   :: forall xs m.
      MonadIO m
   => ActionCtxT (HVect xs) m ()
-storeDeleteGet =
-  $(renderTemplateFromEnv "adminUser_admin_store_delete.html")
+storeDeleteGet = $(renderTemplateFromEnv "adminUser_admin_store_delete.html")
 
 -- | Return the store delete confirmation page for an admin.
 storeDeleteConfirmPost
@@ -190,15 +186,15 @@ storeDeleteConfirmPost
 storeDeleteConfirmPost = do
   (AdminStoreDeleteConfirmForm storeEmailParam) <- getReqParamErr handleErr
   maybeStoreEntity <- dbFindStoreByEmail storeEmailParam
-  (Entity _ Store{storeName = storeName_}) <-
-    fromMaybeOrM maybeStoreEntity $
-    handleErr $ label def AdminErrorNoStoreEmail
+  (Entity _ Store {storeName = storeName_}) <-
+    fromMaybeOrM maybeStoreEntity $ handleErr $ label def AdminErrorNoStoreEmail
   $(renderTemplateFromEnv "adminUser_admin_store_delete_confirm.html")
   where
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
       $(logDebug) $
-        "got following error in admin storeDeleteConfirmPost handler: " <> errMsg
+        "got following error in admin storeDeleteConfirmPost handler: " <>
+        errMsg
       let errors = [errMsg]
       $(renderTemplateFromEnv "adminUser_admin_store_delete.html")
 
@@ -214,20 +210,16 @@ storeDeletePost = do
     res@StoreDeleteSuccess ->
       let messages = [label def res]
       in $(renderTemplateFromEnv "adminUser_admin_store_create.html")
-    res@(StoreDeleteErrDoesNotExist _) ->
-      handleErr $ label def res
+    res@(StoreDeleteErrDoesNotExist _) -> handleErr $ label def res
     res@(StoreDeleteErrNameDoesNotMatch realStore _) ->
-      let
-        storeName_ = storeName realStore
-        errors = [label def res]
-      in
-        $(renderTemplateFromEnv "adminUser_admin_store_delete_confirm.html")
+      let storeName_ = storeName realStore
+          errors = [label def res]
+      in $(renderTemplateFromEnv "adminUser_admin_store_delete_confirm.html")
   where
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
       $(logDebug) $
-        "got following error in admin storeDeletePost handler: " <>
-        errMsg
+        "got following error in admin storeDeletePost handler: " <> errMsg
       let errors = [errMsg]
       $(renderTemplateFromEnv "adminUser_admin_store_delete.html")
 
@@ -238,10 +230,8 @@ adminAuthHook = do
   maybeAdminSession <- getAdminCookie
   case maybeAdminSession of
     Nothing ->
-      let
-        errors = [label def AdminErrorNoAdminSession]
-      in
-        $(renderTemplateFromEnv "adminUser_login.html")
+      let errors = [label def AdminErrorNoAdminSession]
+      in $(renderTemplateFromEnv "adminUser_login.html")
     Just adminSession -> do
       oldCtx <- getContext
       return $ adminSession :&: oldCtx

--- a/src/Kucipong/Handler/Admin/Types.hs
+++ b/src/Kucipong/Handler/Admin/Types.hs
@@ -1,0 +1,23 @@
+module Kucipong.Handler.Admin.Types
+  ( AdminError(..)
+  , AdminMsg(..)
+  ) where
+
+import Kucipong.Prelude
+
+data AdminError
+  = AdminErrorCouldNotSendEmail
+  | AdminErrorNoAdminEmail
+  | AdminErrorNoAdminLoginToken
+  | AdminErrorNoAdminSession
+  | AdminErrorNoStoreEmail
+  | AdminErrorStoreWithSameEmailExists
+  | AdminErrorStoreCreateDbProblem
+  | AdminErrorSendEmailFailure
+  | AdminErrorTokenExpired
+  deriving (Show, Eq, Ord, Read, Enum, Bounded)
+
+data AdminMsg
+  = AdminMsgSentVerificationEmail
+  deriving (Show, Eq, Ord, Read, Enum, Bounded)
+

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -2,13 +2,54 @@
 
 module Kucipong.I18n.Instance where
 
+import Kucipong.Prelude
+
 import Kucipong.I18n.Class (I18n(..))
 import Kucipong.I18n.Types (Lang(..))
 
+import Kucipong.Db (Store(..))
 import Kucipong.Db.Models.Base
-       (BusinessCategory(..), BusinessCategoryDetail(..),
-        FashionDetail(..), GourmetDetail(..), GadgetDetail(..),
-        TravelingDetail(..), BeautyDetail(..), CommonDetail(..))
+       (BeautyDetail(..), BusinessCategory(..),
+        BusinessCategoryDetail(..), CommonDetail(..), FashionDetail(..),
+        GourmetDetail(..), GadgetDetail(..), TravelingDetail(..))
+import Kucipong.Handler.Admin.Types (AdminError(..), AdminMsg(..))
+import Kucipong.Monad.Db.Class (StoreDeleteResult(..))
+
+import Text.EmailAddress (toText)
+
+instance I18n AdminError where
+  label EnUS AdminErrorNoAdminEmail =
+    "Could not login."
+  label EnUS AdminErrorCouldNotSendEmail =
+    "Could not send email."
+  label EnUS AdminErrorNoAdminLoginToken =
+    "Failed to log in X(\nPlease try again."
+  label EnUS AdminErrorTokenExpired =
+    "This log in URL has been expired X(\nPlease try again."
+  label EnUS AdminErrorStoreWithSameEmailExists =
+    "Store with that email address already exists."
+  label EnUS AdminErrorStoreCreateDbProblem =
+    "Problem with database."
+  label EnUS AdminErrorSendEmailFailure =
+    "Could not send email."
+  label EnUS AdminErrorNoStoreEmail =
+    "Could not find a store with that email address."
+  label EnUS AdminErrorNoAdminSession =
+    "Need to be logged in as admin in order to access this page."
+
+instance I18n AdminMsg where
+  label EnUS AdminMsgSentVerificationEmail =
+    "We have sent you email with verification URL."
+
+instance I18n StoreDeleteResult where
+  label EnUS StoreDeleteSuccess = "Successfully deleted store."
+  label EnUS (StoreDeleteErrNameDoesNotMatch realStore given) =
+    "Store name \"" <> given <>
+      "\" does not match the real store name \"" <>
+      storeName realStore <>
+      "\"."
+  label EnUS (StoreDeleteErrDoesNotExist email) =
+    "Store with email address of \"" <> toText email <> "\" does not exist"
 
 instance I18n BusinessCategory where
   label EnUS Gourmet = "Gourmet"

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -18,20 +18,16 @@ import Kucipong.Monad.Db.Class (StoreDeleteResult(..))
 import Text.EmailAddress (toText)
 
 instance I18n AdminError where
-  label EnUS AdminErrorNoAdminEmail =
-    "Could not login."
-  label EnUS AdminErrorCouldNotSendEmail =
-    "Could not send email."
+  label EnUS AdminErrorNoAdminEmail = "Could not login."
+  label EnUS AdminErrorCouldNotSendEmail = "Could not send email."
   label EnUS AdminErrorNoAdminLoginToken =
     "Failed to log in X(\nPlease try again."
   label EnUS AdminErrorTokenExpired =
     "This log in URL has been expired X(\nPlease try again."
   label EnUS AdminErrorStoreWithSameEmailExists =
     "Store with that email address already exists."
-  label EnUS AdminErrorStoreCreateDbProblem =
-    "Problem with database."
-  label EnUS AdminErrorSendEmailFailure =
-    "Could not send email."
+  label EnUS AdminErrorStoreCreateDbProblem = "Problem with database."
+  label EnUS AdminErrorSendEmailFailure = "Could not send email."
   label EnUS AdminErrorNoStoreEmail =
     "Could not find a store with that email address."
   label EnUS AdminErrorNoAdminSession =
@@ -44,10 +40,9 @@ instance I18n AdminMsg where
 instance I18n StoreDeleteResult where
   label EnUS StoreDeleteSuccess = "Successfully deleted store."
   label EnUS (StoreDeleteErrNameDoesNotMatch realStore given) =
-    "Store name \"" <> given <>
-      "\" does not match the real store name \"" <>
-      storeName realStore <>
-      "\"."
+    "Store name \"" <> given <> "\" does not match the real store name \"" <>
+    storeName realStore <>
+    "\"."
   label EnUS (StoreDeleteErrDoesNotExist email) =
     "Store with email address of \"" <> toText email <> "\" does not exist"
 

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -18,16 +18,20 @@ import Kucipong.Monad.Db.Class (StoreDeleteResult(..))
 import Text.EmailAddress (toText)
 
 instance I18n AdminError where
-  label EnUS AdminErrorNoAdminEmail = "Could not login."
-  label EnUS AdminErrorCouldNotSendEmail = "Could not send email."
+  label EnUS AdminErrorNoAdminEmail =
+    "Could not login. This email address has not been registered as an admin user yet."
+  label EnUS AdminErrorCouldNotSendEmail =
+    "Could not send email. Please try again."
   label EnUS AdminErrorNoAdminLoginToken =
-    "Failed to log in X(\nPlease try again."
+    "Failed to login. Please try again."
   label EnUS AdminErrorTokenExpired =
-    "This log in URL has been expired X(\nPlease try again."
+    "This login URL has been expired. Please try again."
   label EnUS AdminErrorStoreWithSameEmailExists =
     "Store with that email address already exists."
-  label EnUS AdminErrorStoreCreateDbProblem = "Problem with database."
-  label EnUS AdminErrorSendEmailFailure = "Could not send email."
+  label EnUS AdminErrorStoreCreateDbProblem =
+    "Problem with database. Please try again."
+  label EnUS AdminErrorSendEmailFailure =
+    "Could not send email. Please try again."
   label EnUS AdminErrorNoStoreEmail =
     "Could not find a store with that email address."
   label EnUS AdminErrorNoAdminSession =
@@ -40,11 +44,11 @@ instance I18n AdminMsg where
 instance I18n StoreDeleteResult where
   label EnUS StoreDeleteSuccess = "Successfully deleted store."
   label EnUS (StoreDeleteErrNameDoesNotMatch realStore given) =
-    "Store name \"" <> given <> "\" does not match the real store name \"" <>
+    "Entered store name \"" <> given <> "\" does not match the real store name \"" <>
     storeName realStore <>
     "\"."
   label EnUS (StoreDeleteErrDoesNotExist email) =
-    "Store with email address of \"" <> toText email <> "\" does not exist"
+    "Store with email address of \"" <> toText email <> "\" does not exist."
 
 instance I18n BusinessCategory where
   label EnUS Gourmet = "Gourmet"

--- a/src/Kucipong/I18n/Types.hs
+++ b/src/Kucipong/I18n/Types.hs
@@ -2,6 +2,16 @@ module Kucipong.I18n.Types
   ( Lang(..)
   ) where
 
+import Kucipong.Prelude
+
+import Data.Default (Default(..))
+
 -- | Language to show web page contents in
 data Lang
   = EnUS
+  deriving (Show, Eq, Read, Ord, Enum, Bounded)
+
+-- | Default language for rendering pages.
+-- In development phase, we use 'EnUS' as default temporary.
+instance Default Lang where
+  def = EnUS

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -20,9 +20,9 @@ import Kucipong.Monad.SendEmail.Trans (KucipongSendEmailT)
 data StoreDeleteResult
   = StoreDeleteSuccess
   -- ^ Successfully deleted the store.
-  | StoreDeleteErrNameDoesNotMatch Store
+  | StoreDeleteErrNameDoesNotMatch Store Text
   -- ^ 'Store' name passed in does not match the name of the actual 'Store'.
-  | StoreDeleteErrDoesNotExist
+  | StoreDeleteErrDoesNotExist EmailAddress
   -- ^ 'EmailAddress' passed in does not match an actual 'Store'.
   deriving (Eq, Generic, Show, Typeable)
 

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -194,8 +194,8 @@ instance ( MonadBaseControl IO m
               | storeName store == name -> do
                 update storeKey [StoreDeleted =. Just (DeletedTime currTime)]
                 pure StoreDeleteSuccess
-              | otherwise -> pure $ StoreDeleteErrNameDoesNotMatch store
-            Nothing -> pure StoreDeleteErrDoesNotExist
+              | otherwise -> pure $ StoreDeleteErrNameDoesNotMatch store name
+            Nothing -> pure $ StoreDeleteErrDoesNotExist email
 
 
   -- ======= --

--- a/src/Kucipong/RenderTemplate.hs
+++ b/src/Kucipong/RenderTemplate.hs
@@ -7,12 +7,13 @@ module Kucipong.RenderTemplate
 
 import           Kucipong.Prelude           hiding (try)
 
+import Data.Default (def)
 import           Text.Blaze.Renderer.Text   (renderMarkup)
 import           Language.Haskell.TH        (Exp, Q, appE)
 import           Text.Heterocephalus        (compileHtmlFileWithDefault)
 import           Web.Spock                  (html)
 
-import           Kucipong.I18n (Lang(..), label)
+import           Kucipong.I18n (label)
 
 templateDirectory :: FilePath
 templateDirectory = "frontend" </> "dist"
@@ -35,7 +36,7 @@ renderTemplateFromEnv filename = renderer `appE` body
         , ("isSelected", [|isSelected|])
         , ("isChecked", [|isChecked|])
         , ("key", [|key|])
-        , ("label", [|label EnUS|])
+        , ("label", [|label def|])
         ]
 
     renderer :: Q Exp

--- a/src/Kucipong/RenderTemplate.hs
+++ b/src/Kucipong/RenderTemplate.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Kucipong.RenderTemplate
   ( renderTemplateFromEnv
   ) where
 
-import           Kucipong.Prelude           hiding (try)
+import Kucipong.Prelude hiding (try)
 
 import Data.Default (def)
-import           Text.Blaze.Renderer.Text   (renderMarkup)
-import           Language.Haskell.TH        (Exp, Q, appE)
-import           Text.Heterocephalus        (compileHtmlFileWithDefault)
-import           Web.Spock                  (html)
+import Language.Haskell.TH (Exp, Q, appE)
+import Text.Blaze.Renderer.Text (renderMarkup)
+import Text.Heterocephalus (compileHtmlFileWithDefault)
+import Web.Spock (html)
 
-import           Kucipong.I18n (label)
+import Kucipong.I18n (label)
 
 templateDirectory :: FilePath
 templateDirectory = "frontend" </> "dist"
@@ -26,7 +26,6 @@ renderTemplateFromEnv filename = renderer `appE` body
     -- This is the full path of the template file.
     fullFilePath :: FilePath
     fullFilePath = templateDirectory </> filename
-
     body :: Q Exp
     body =
       compileHtmlFileWithDefault
@@ -38,28 +37,31 @@ renderTemplateFromEnv filename = renderer `appE` body
         , ("key", [|key|])
         , ("label", [|label def|])
         ]
-
     renderer :: Q Exp
     renderer = [|html . toStrict . renderMarkup|]
 
 -- | For the purpose of rendering 'selected' attributes in the template file.
-isSelected :: (Eq a)
-           => Maybe a  -- A selected key. 'Nothing' when no options are selected.
-           -> a       -- A key to check if it is selected.
-           -> Text    -- "selected" | ""
+isSelected
+  :: (Eq a)
+  => Maybe a -- A selected key. 'Nothing' when no options are selected.
+  -> a -- A key to check if it is selected.
+  -> Text -- "selected" | ""
 isSelected (Just a) b
   | a == b = "selected"
 isSelected _ _ = ""
 
 -- | For the purpose of rendering 'checked' attributes in the template file.
-isChecked :: (Eq a)
-          => [a]    -- A key list of selected objects.
-          -> a      -- A key to check if it is checked.
-          -> Text   -- "checked" | ""
+isChecked
+  :: (Eq a)
+  => [a] -- A key list of selected objects.
+  -> a -- A key to check if it is checked.
+  -> Text -- "checked" | ""
 isChecked ls k
   | k `elem` ls = "checked"
   | otherwise = ""
 
 -- | Key
-key :: (Show a) => a -> Text
+key
+  :: (Show a)
+  => a -> Text
 key = tshow


### PR DESCRIPTION
This is a part of #62.
Main changes are in  e788f01.
To i18n for admin pages, `StoreDeleteResult` type became to contain more informations. (fa4a3b9)
Messages are edited to be more user friendly in bde6385.
It is welcome to edit names of types for i18n and messages to show in page.

@cdepillabout , please review.