### PR TITLE
validate business category details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,17 +52,17 @@ install:
   set -ex
   cd frontend/
   # TODO: We could try installing npm packages globally, and then cache that directory.
-  npm install
+  time npm install
   cd ../
-  stack --no-terminal --install-ghc test --bench --only-dependencies
+  time stack --no-terminal --install-ghc test --bench --only-dependencies
   set +ex
 
 script:
 - |
   set -ex
   cd frontend/
-  npm run build
+  time npm run build
   cd ../
   # TODO: haddock fails with ghc-8.0.1.  Reenable haddock when we get lts-8.
-  stack --no-terminal test --bench --no-run-benchmarks # --haddock --no-haddock-deps
+  time stack --no-terminal test --bench --no-run-benchmarks # --haddock --no-haddock-deps
   set +ex

--- a/src/Kucipong/Db/Models.hs
+++ b/src/Kucipong/Db/Models.hs
@@ -13,15 +13,13 @@ module Kucipong.Db.Models
 
 import Kucipong.Prelude
 
-import Database.Persist
-    ( EntityField(..), Key(..), Unique )
-import Database.Persist.TH (
-    share, mkPersist, sqlSettings, mkMigrate, mpsGenerateLenses,
-    )
+import Database.Persist (EntityField(..), Key(..), Unique)
+import Database.Persist.TH
+       (share, mkPersist, sqlSettings, mkMigrate, mpsGenerateLenses)
 
 import Kucipong.Db.Models.Base
-import Kucipong.Db.Models.EntityDefs ( kucipongEntityDefs )
-import Kucipong.LoginToken ( LoginToken )
+import Kucipong.Db.Models.EntityDefs (kucipongEntityDefs)
+import Kucipong.LoginToken (LoginToken)
 
 share [ mkPersist sqlSettings { mpsGenerateLenses = False }
       , mkMigrate "migrateAll"

--- a/src/Kucipong/Db/Models.hs
+++ b/src/Kucipong/Db/Models.hs
@@ -20,8 +20,6 @@ import Database.Persist.TH (
     )
 
 import Kucipong.Db.Models.Base
-    ( BusinessCategory(..), BusinessCategoryDetail(..), CouponType, CreatedTime(..), DeletedTime(..), FashionDetail(..), GourmetDetail(..), Image
-    , LoginTokenExpirationTime(..), Percent, Price, UpdatedTime(..) )
 import Kucipong.Db.Models.EntityDefs ( kucipongEntityDefs )
 import Kucipong.LoginToken ( LoginToken )
 

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -487,3 +487,21 @@ instance FromJSON BusinessCategoryDetail where
 
 instance FromHttpApiData BusinessCategoryDetail where
   parseUrlPiece = businessCategoryDetailFromText
+
+-- | Returns whether a given 'BusinessCategoryDetail' works in a
+-- 'BusinessCategory'. 'CommonDetail's are valid for every 'BusinessCategory'.
+--
+-- >>> isValidBusinessCategoryDetailFor Gourmet (GourmetDetail GourmetSushi)
+-- True
+-- >>> isValidBusinessCategoryDetailFor Fashion (GourmetDetail GourmetSushi)
+-- False
+-- >>> isValidBusinessCategoryDetailFor Gadget (CommonDetail CommonPoliteService)
+-- True
+isValidBusinessCategoryDetailFor :: BusinessCategory -> BusinessCategoryDetail -> Bool
+isValidBusinessCategoryDetailFor Gourmet (GourmetDetail _) = True
+isValidBusinessCategoryDetailFor Fashion (FashionDetail _) = True
+isValidBusinessCategoryDetailFor Gadget (GadgetDetail _) = True
+isValidBusinessCategoryDetailFor Traveling (TravelingDetail _) = True
+isValidBusinessCategoryDetailFor Beauty (BeautyDetail _) = True
+isValidBusinessCategoryDetailFor _ (CommonDetail _) = True
+isValidBusinessCategoryDetailFor _ _ = False

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -8,6 +8,7 @@ import Control.FromSum (fromMaybeOrM)
 import Data.Aeson ( FromJSON, ToJSON, Value, parseJSON, toJSON )
 import Data.Aeson.TH (defaultOptions, deriveJSON)
 import Data.Aeson.Types (parseMaybe, typeMismatch)
+import Data.Data (toConstr)
 import Data.Kind (Constraint)
 import Database.Persist ( PersistField(..), PersistValue )
 import Database.Persist.Sql ( PersistFieldSql(..), SqlType )
@@ -491,17 +492,29 @@ instance FromHttpApiData BusinessCategoryDetail where
 -- | Returns whether a given 'BusinessCategoryDetail' works in a
 -- 'BusinessCategory'. 'CommonDetail's are valid for every 'BusinessCategory'.
 --
+-- This currently just compares the 'BusinessCategory' constructor to the first
+-- characters of the 'BusinessCategoryDetail' constructor and tests if they are
+-- the same.
+--
+-- For instance, the 'Gourmet' constructor matches the 'GourmetDetail'
+-- constructor.
+--
 -- >>> isValidBusinessCategoryDetailFor Gourmet (GourmetDetail GourmetSushi)
 -- True
+--
+-- However, the 'Fashion' constructor doesn't match the 'GourmetDetail'
+-- constructor.
+--
 -- >>> isValidBusinessCategoryDetailFor Fashion (GourmetDetail GourmetSushi)
 -- False
+--
+-- The 'CommonDetail' constructor works for any 'BusinessCategory'.
+--
 -- >>> isValidBusinessCategoryDetailFor Gadget (CommonDetail CommonPoliteService)
 -- True
 isValidBusinessCategoryDetailFor :: BusinessCategory -> BusinessCategoryDetail -> Bool
-isValidBusinessCategoryDetailFor Gourmet (GourmetDetail _) = True
-isValidBusinessCategoryDetailFor Fashion (FashionDetail _) = True
-isValidBusinessCategoryDetailFor Gadget (GadgetDetail _) = True
-isValidBusinessCategoryDetailFor Traveling (TravelingDetail _) = True
-isValidBusinessCategoryDetailFor Beauty (BeautyDetail _) = True
-isValidBusinessCategoryDetailFor _ (CommonDetail _) = True
-isValidBusinessCategoryDetailFor _ _ = False
+isValidBusinessCategoryDetailFor busiCat busiCatDet =
+  let busiCatConstr = toConstr busiCat
+      busiCatDetConstr = toConstr busiCatDet
+  in show busiCatConstr `isPrefixOf` show busiCatDetConstr ||
+     "Common" `isPrefixOf` show busiCatDetConstr

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -13,15 +13,17 @@ import Data.HVect (HVect(..))
 import Database.Persist (Entity(..))
 import Web.Routing.Combinators (PathState(Open))
 import Web.Spock
-       (ActionCtxT, Path, UploadedFile(..), (<//>), files, getContext, prehook, root,
-        redirect, renderRoute, var)
+       (ActionCtxT, Path, UploadedFile(..), (<//>), files, getContext,
+        params, prehook, root, redirect, renderRoute, var)
 import Web.Spock.Core (SpockCtxT, get, post)
 
 import Kucipong.Db
-       (Key(..), LoginTokenExpirationTime(..), Store(..),
+       (BusinessCategory(..), BusinessCategoryDetail(..), Key(..),
+        LoginTokenExpirationTime(..), Store(..),
         StoreLoginToken(storeLoginTokenExpirationTime,
-                        storeLoginTokenLoginToken))
-import Kucipong.Db (BusinessCategory(..), BusinessCategoryDetail(..))
+                        storeLoginTokenLoginToken),
+        isValidBusinessCategoryDetailFor, readBusinessCategory,
+        unfoldAllBusinessCategoryDetailAlt)
 import Kucipong.Email (EmailError)
 import Kucipong.Form
        (StoreEditForm(..), StoreLoginForm(StoreLoginForm))
@@ -214,21 +216,20 @@ storeEditPost = do
       url
   redirect . renderRoute $ storeUrlPrefix
   where
-    -- TODO: put previous input texts
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
+      p <- params
       $(logDebug) $ "got following error in storeEditPost handler: " <> errMsg
-      let
-        errors = [errMsg]
-        name = Nothing :: Maybe Text
-        businessCategory = Nothing :: Maybe BusinessCategory
-        businessCategoryDetails = [] :: [BusinessCategoryDetail]
-        salesPoint = Nothing :: Maybe Text
-        address = Nothing :: Maybe Text
-        phoneNumber = Nothing :: Maybe Text
-        businessHourLines = [] :: [Text]
-        regularHoliday = Nothing :: Maybe Text
-        url = Nothing :: Maybe Text
+      let errors = [errMsg]
+          name = lookup "name" p
+          businessCategory = readBusinessCategory =<< lookup "businessCategory" p
+          businessCategoryDetails = businessCategoryDetailsFromParams p
+          salesPoint = lookup "salesPoint" p
+          address = lookup "address" p
+          phoneNumber = lookup "phoneNumber" p
+          businessHourLines = maybe [] (lines) $ lookup "businessHours" p
+          regularHoliday = lookup "regularHoliday" p
+          url = lookup "url" p
       $(renderTemplateFromEnv "storeUser_store_edit.html")
 
 storeAuthHook
@@ -271,3 +272,24 @@ allBusinessCategoryDetails (Just Gadget) = map GadgetDetail [minBound .. maxBoun
 allBusinessCategoryDetails (Just Traveling) = map TravelingDetail [minBound .. maxBound]
 allBusinessCategoryDetails (Just Beauty) = map BeautyDetail [minBound .. maxBound]
 allBusinessCategoryDetails Nothing = map CommonDetail [minBound .. maxBound]
+
+-- | Take the list of all parameters (which includes business category details)
+-- returned from 'params', and return only those which are valid
+-- 'BusinessCategoryDetail's.
+--
+-- >>> let nameParam = ("name", "foo store")
+-- >>> let busCatDetParam1 = ("businessCategoryDetails", "GourmetSushi")
+-- >>> let busCatDetParam2 = ("businessCategoryDetails", "TravelingAsia")
+-- >>> let busCatDetParamBad = ("businessCategoryDetails", "foobarbaz")
+-- >>> let ps = [nameParam, busCatDetParam1, busCatDetParam2, busCatDetParamBad]
+-- >>> businessCategoryDetailsFromParams ps
+-- [GourmetSushi,TravelingAsia]
+businessCategoryDetailsFromParams :: [(Text, Text)] -> [BusinessCategoryDetail]
+businessCategoryDetailsFromParams =
+  catMaybes .
+  map (unfoldAllBusinessCategoryDetailAlt (Proxy :: Proxy Read) readMay) .
+  filterBusinessCategoryDetails
+  where
+    filterBusinessCategoryDetails :: [(Text, Text)] -> [Text]
+    filterBusinessCategoryDetails =
+      fmap snd . filter (\(key, _) -> key == "businessCategoryDetails")

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -9,6 +9,7 @@ import Kucipong.Handler.Store.Types (StoreError(..), StoreMsg(..))
 import Control.FromSum (fromMaybeM)
 import Control.Monad.Time (MonadTime(..))
 import Data.Default (def)
+import Data.List (nub)
 import Data.HVect (HVect(..))
 import Database.Persist (Entity(..))
 import Web.Routing.Combinators (PathState(Open))
@@ -207,7 +208,7 @@ storeEditPost = do
       email
       name
       businessCategory
-      businessCategoryDetails
+      (nub businessCategoryDetails)
       Nothing
       salesPoint
       address
@@ -284,17 +285,19 @@ allBusinessCategoryDetails Nothing = map CommonDetail [minBound .. maxBound]
 
 -- | Take the list of all parameters (which includes business category details)
 -- returned from 'params', and return only those which are valid
--- 'BusinessCategoryDetail's.
+-- 'BusinessCategoryDetail's.  Remove duplicates.
 --
 -- >>> let nameParam = ("name", "foo store")
 -- >>> let busCatDetParam1 = ("businessCategoryDetails", "GourmetSushi")
 -- >>> let busCatDetParam2 = ("businessCategoryDetails", "TravelingAsia")
+-- >>> let busCatDetParam3 = ("businessCategoryDetails", "GourmetSushi")
 -- >>> let busCatDetParamBad = ("businessCategoryDetails", "foobarbaz")
--- >>> let ps = [nameParam, busCatDetParam1, busCatDetParam2, busCatDetParamBad]
+-- >>> let ps = [nameParam, busCatDetParam1, busCatDetParam2, busCatDetParam3, busCatDetParamBad]
 -- >>> businessCategoryDetailsFromParams ps
 -- [GourmetSushi,TravelingAsia]
 businessCategoryDetailsFromParams :: [(Text, Text)] -> [BusinessCategoryDetail]
 businessCategoryDetailsFromParams =
+  nub .
   catMaybes .
   map (unfoldAllBusinessCategoryDetailAlt (Proxy :: Proxy Read) readMay) .
   filterBusinessCategoryDetails

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -201,6 +201,7 @@ storeEditPost = do
       -- s3UploadFile originalFileName contentType tempLocation
       pure ()
     Nothing -> handleErr $ I18n.label def StoreErrorNoImage
+  checkBusinessCategoryDetails businessCategory businessCategoryDetails
   void $
     dbUpsertStore
       email
@@ -216,6 +217,14 @@ storeEditPost = do
       url
   redirect . renderRoute $ storeUrlPrefix
   where
+    checkBusinessCategoryDetails :: BusinessCategory
+                                 -> [BusinessCategoryDetail]
+                                 -> ActionCtxT (HVect xs) m ()
+    checkBusinessCategoryDetails busiCat busiCatDets
+      | all (isValidBusinessCategoryDetailFor busiCat) busiCatDets = pure ()
+      | otherwise =
+        handleErr $ I18n.label def StoreErrorBusinessCategoryDetailIncorrect
+
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
       p <- params

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -6,7 +6,8 @@ module Kucipong.Handler.Store.Types
 import Kucipong.Prelude
 
 data StoreError
-  = StoreErrorCouldNotSendEmail
+  = StoreErrorBusinessCategoryDetailIncorrect
+  | StoreErrorCouldNotSendEmail
   | StoreErrorNoImage
   | StoreErrorNoStoreEmail EmailAddress
   deriving (Show, Eq, Ord, Read)

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -52,6 +52,8 @@ instance I18n StoreDeleteResult where
     "Store with email address of \"" <> toText email <> "\" does not exist."
 
 instance I18n StoreError where
+  label EnUS StoreErrorBusinessCategoryDetailIncorrect =
+    "Business category details do not belong to the selected business category."
   label EnUS StoreErrorCouldNotSendEmail =
     "Could not send email. Please try again."
   label EnUS StoreErrorNoImage =


### PR DESCRIPTION
This PR includes two major pieces of functionality.

- commit efba13d
   - Check to make sure that only business category details for the selected
	 business category can be used in the store edit handler.  For instance,
	 if the business category `Gourmet` is selected, we do not allow a business
	 category detail of `TravelingAsia`.

- commit b3d06fb
   - When editing a store, return the current values to the user if there was
	 an error.  This makes it easier for the user to correct the one single
	 error and quickly resubmit the form.

Closes #65.