### PR TITLE
Render with params

### DIFF
--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -34,7 +34,8 @@ import Kucipong.Monad
        (MonadKucipongCookie, MonadKucipongDb(..),
         MonadKucipongSendEmail(..), dbFindStoreByEmail,
         dbFindStoreLoginToken, dbUpsertStore)
-import Kucipong.RenderTemplate (renderTemplateFromEnv)
+import Kucipong.RenderTemplate
+       (fromParams, renderTemplate, renderTemplateFromEnv)
 import Kucipong.Session (Store, Session(..))
 import Kucipong.Spock
        (ContainsStoreSession, getReqParamErr, getStoreCookie,
@@ -225,22 +226,25 @@ storeEditPost = do
       | all (isValidBusinessCategoryDetailFor busiCat) busiCatDets = pure ()
       | otherwise =
         handleErr $ label def StoreErrorBusinessCategoryDetailIncorrect
-
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
       p <- params
       $(logDebug) $ "got following error in storeEditPost handler: " <> errMsg
       let errors = [errMsg]
-          name = lookup "name" p
-          businessCategory = readBusinessCategory =<< lookup "businessCategory" p
+          businessCategory =
+            readBusinessCategory =<< lookup "businessCategory" p
           businessCategoryDetails = businessCategoryDetailsFromParams p
-          salesPoint = lookup "salesPoint" p
-          address = lookup "address" p
-          phoneNumber = lookup "phoneNumber" p
           businessHourLines = maybe [] (lines) $ lookup "businessHours" p
-          regularHoliday = lookup "regularHoliday" p
-          url = lookup "url" p
-      $(renderTemplateFromEnv "storeUser_store_edit.html")
+      $(renderTemplate "storeUser_store_edit.html" $
+        fromParams
+          [|p|]
+          [ "name"
+          , "salesPoint"
+          , "address"
+          , "phoneNumber"
+          , "regularHoliday"
+          , "url"
+          ])
 
 storeAuthHook
   :: (MonadIO m, MonadKucipongCookie m)

--- a/src/Kucipong/RenderTemplate.hs
+++ b/src/Kucipong/RenderTemplate.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Kucipong.RenderTemplate
-  ( renderTemplate
+  ( fromParams
+  , renderTemplate
   , renderTemplateFromEnv
   ) where
 
@@ -18,6 +19,18 @@ import Kucipong.I18n (label)
 
 templateDirectory :: FilePath
 templateDirectory = "frontend" </> "dist"
+
+-- | The `fromParams` construct a `ScopeM ()` from parameter lists.
+fromParams
+  :: Q Exp -- ^ @$(qdict) :: [('Text', 'Text')]@
+  -> [Text]
+  -> ScopeM ()
+fromParams qdict list = foldr f (pure ()) list
+  where
+    f :: Text -> ScopeM () -> ScopeM ()
+    f name scope = do
+      scope
+      overwrite (fromString . unpack $ name) ([|lookup name|] `appE` qdict)
 
 -- | Render a template file with adding empty @errors@ and @messages@ keys/values
 -- if they don't already exist in scope.


### PR DESCRIPTION
This PR resolves #75.
In #78, I've introduced new render function that takes extra template variables specified by `String`-like variable name.
This PR add another `ScopeM ()` constructor named `fromParams` which takes parameters list (`:: [(Text, Text)]`).
The commit f77d5861ac62257fa5bce18e8291f02c8729fec6 actually rewrites codes with `fromParams`.

@cdepillabout 
Is this what you intended?