### PR TITLE
/store/coupon GET handler and /store/coupon/<id> GET handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,5 @@ script:
   time npm run build
   cd ../
   # TODO: haddock fails with ghc-8.0.1.  Reenable haddock when we get lts-8.
-  time stack --no-terminal test --bench --no-run-benchmarks # --haddock --no-haddock-deps
+  time travis_wait 30 stack --no-terminal test --bench --no-run-benchmarks # --haddock --no-haddock-deps
   set +ex

--- a/frontend/src/pug/_couponSimple.pug
+++ b/frontend/src/pug/_couponSimple.pug
@@ -1,11 +1,45 @@
 .couponSimple
-  a.card(href="/coupon/3")
+  a.card(href="/store/coupon/\#{ fromSqlKey (entityKey couponEntity) }")
     .annotatedImageGroup
-      img.annotatedImageGroup-image(src=require("../img/dummy.jpg") alt="七輪焼き肉・安安")
+      img.annotatedImageGroup-image(src=require("../img/dummy.jpg") alt="\#{ couponTitle (entityVal couponEntity) }")
       span.annotatedImageGroup-annotation 画像は一例です
     .card_body
       .couponSimple_abstraction
-        h2.couponSimple_abstraction-store 七輪焼肉・安安
+        h2.couponSimple_abstraction-store \#{ couponTitle (entityVal couponEntity) }
         .couponSimple_abstraction-summary
-          span.couponSimple_abstraction-summary-sub 10% OFF
-          span.couponSimple_abstraction-summary-main 3600円
+
+          | %{ if couponTypeIs couponEntity CouponTypeDiscount }
+          |     %{ if isJust (couponDiscountPercent (entityVal couponEntity)) }
+          span.couponSimple_abstraction-summary-sub \#{ fromMaybe 0 (couponDiscountPercent (entityVal couponEntity)) }% OFF
+          |     %{ endif }
+          |     %{ if isJust (couponDiscountMinimumPrice (entityVal couponEntity)) }
+          span.couponSimple_abstraction-summary-main \#{ fromMaybe 0 (couponDiscountMinimumPrice (entityVal couponEntity)) }円
+          |     %{ endif }
+          | %{ endif }
+
+
+          | %{ if couponTypeIs couponEntity CouponTypeGift }
+          |     %{ if isJust (couponGiftContent (entityVal couponEntity)) }
+          span.couponSimple_abstraction-summary-sub \#{ fromMaybe "" (couponGiftContent (entityVal couponEntity)) }
+          |     %{ endif }
+          |     %{ if isJust (couponGiftMinimumPrice (entityVal couponEntity)) }
+          span.couponSimple_abstraction-summary-main \#{ fromMaybe 0 (couponGiftMinimumPrice (entityVal couponEntity)) }円
+          |     %{ endif }
+          | %{ endif }
+
+
+          | %{ if couponTypeIs couponEntity CouponTypeSet }
+          |     %{ if isJust (couponSetContent (entityVal couponEntity)) }
+          span.couponSimple_abstraction-summary-sub \#{ fromMaybe "" (couponSetContent (entityVal couponEntity)) }
+          |     %{ endif }
+          |     %{ if isJust (couponSetPrice (entityVal couponEntity)) }
+          span.couponSimple_abstraction-summary-main \#{ fromMaybe 0 (couponSetPrice (entityVal couponEntity)) }円
+          |     %{ endif }
+          | %{ endif }
+
+
+          | %{ if couponTypeIs couponEntity CouponTypeOther }
+          |     %{ if isJust (couponOtherContent (entityVal couponEntity)) }
+          span.couponSimple_abstraction-summary-sub \#{ fromMaybe "" (couponOtherContent (entityVal couponEntity)) }
+          |     %{ endif }
+          | %{ endif }

--- a/frontend/src/pug/_coupon_id.pug
+++ b/frontend/src/pug/_coupon_id.pug
@@ -1,18 +1,30 @@
 .coupon
   .card
     .card_header
-      h2.card_header_text 七輪焼肉・安安
+      h2.card_header_text \%{if isJust maybeStoreEntity}\#{maybe mempty (storeName . entityVal) maybeStoreEntity}\%{else}(no title)\%{endif}
       .card_header_icon
         .icon.icon-fav.checkableIcon
-          input#js-fav-3.checkableIcon-check.js-fav(type="checkbox" data-coupon-id="3")
+          input#js-fav-3.checkableIcon-check.js-fav(type="checkbox" data-coupon-id="\#{fromSqlKey (entityKey (fromJustEx maybeCouponEntity))}")
           label.checkableIcon-icon(for="js-fav-3")
+
     .annotatedImageGroup
       img.annotatedImageGroup-image(src=require("../img/dummy.jpg") alt="七輪焼き肉・安安")
       span.annotatedImageGroup-annotation 画像は一例です
     .card_body
       .card_body_title
-        | 当日OK! 21時以降のご予約で2.5H飲放題付き料理4品で3,600円
+        | \#{couponTitle (entityVal (fromJustEx maybeCouponEntity))}
+
       .card_body_summary.highlightedBlock
+        | %{ if couponTypeIs (fromJustEx maybeCouponEntity) CouponTypeDiscount }
+        |     %{ if isJust (couponDiscountPercent (entityVal (fromJustEx maybeCouponEntity))) }
+        span.highlightedBlock-sub \#{ fromMaybe 0 (couponDiscountPercent (entityVal (fromJustEx maybeCouponEntity))) }% OFF
+        |     %{ endif }
+        |     %{ if isJust (couponDiscountMinimumPrice (entityVal (fromJustEx maybeCouponEntity))) }
+        span.highlightedBlock-main \#{ fromMaybe 0 (couponDiscountMinimumPrice (entityVal (fromJustEx maybeCouponEntity))) }円
+        |     %{ endif }
+        | %{ endif }
+
+
         span.highlightedBlock-sub 10% OFF
         span.highlightedBlock-main 3600円
       .card_body_expiration
@@ -25,7 +37,7 @@
     .location_map(data-latitude="41.40243" data-longitude="2.17551")
       iframe.location_map-frame(src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d6483.579410111866!2d139.6998074!3d35.6575525!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188b59d79dd993%3A0xdef2b8ece045887e!2z5LiD6Lyq54S86IKJIOWuieWuiSDmuIvosLflupc!5e0!3m2!1sja!2sjp!4v1471871614830" frameborder="0" style="border:0" allowfullscreen)
   .aboutStore
-    a.btn.outerBtn(href="/store/52") 七輪焼き肉・安安
+    a.btn.outerBtn(href="/store") 七輪焼き肉・安安
   .moreContents
     p.moreContents_txt 2.5時間飲放題付きの料理4品です。
     p.moreContents_txt 1. 前菜 2. 焼き肉盛り合わせ 3. 冷麺 4. アイスクリーム

--- a/frontend/src/pug/_coupon_id.pug
+++ b/frontend/src/pug/_coupon_id.pug
@@ -1,7 +1,7 @@
 .coupon
   .card
     .card_header
-      h2.card_header_text \%{if isJust maybeStoreEntity}\#{maybe mempty (storeName . entityVal) maybeStoreEntity}\%{else}(no title)\%{endif}
+      h2.card_header_text %{if isJust maybeStoreEntity}\#{maybe mempty (storeName . entityVal) maybeStoreEntity}%{else}(no title)%{endif}
       .card_header_icon
         .icon.icon-fav.checkableIcon
           input#js-fav-3.checkableIcon-check.js-fav(type="checkbox" data-coupon-id="\#{fromSqlKey (entityKey (fromJustEx maybeCouponEntity))}")

--- a/frontend/src/pug/_coupon_id.pug
+++ b/frontend/src/pug/_coupon_id.pug
@@ -1,7 +1,7 @@
 .coupon
   .card
     .card_header
-      h2.card_header_text %{if isJust maybeStoreEntity}\#{maybe mempty (storeName . entityVal) maybeStoreEntity}%{else}(no title)%{endif}
+      h2.card_header_text \#{maybe "(no title)" (storeName . entityVal) maybeStoreEntity}
       .card_header_icon
         .icon.icon-fav.checkableIcon
           input#js-fav-3.checkableIcon-check.js-fav(type="checkbox" data-coupon-id="\#{fromSqlKey (entityKey (fromJustEx maybeCouponEntity))}")

--- a/frontend/src/pug/storeUser_store_coupon.pug
+++ b/frontend/src/pug/storeUser_store_coupon.pug
@@ -6,6 +6,10 @@ include _layout
       .store_editBtn
         a.btn.outerBtn(href="/store/coupon/create") クーポン追加
 
+    | %{ if null couponEntities }
+    |   No Coupons
+    | %{ else }
+    |   %{ forall couponEntity <- couponEntities }
     include _couponSimple
-    include _couponSimple
-    include _couponSimple
+    |   %{ endforall }
+    | %{ endif }

--- a/frontend/src/pug/storeUser_store_coupon_id.pug
+++ b/frontend/src/pug/storeUser_store_coupon_id.pug
@@ -2,7 +2,11 @@ include _layout
   body#main.wrapper
     include _storeHeader
       | クーポン情報
+    | %{if isJust maybeCouponEntity}
     .store
       .store_editBtn
-        a.btn.outerBtn(href="/store/coupon/3/edit") クーポン情報編集
+        a.btn.outerBtn(href="/store/coupon/\#{fromSqlKey (entityKey (fromJustEx maybeCouponEntity))}/edit") クーポン情報編集
     include _coupon_id
+    | %{else}
+    | No coupon info.
+    | %{endif}

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -13,7 +13,8 @@ import Data.Kind (Constraint)
 import Database.Persist ( PersistField(..), PersistValue )
 import Database.Persist.Sql ( PersistFieldSql(..), SqlType )
 import Database.Persist.TH (derivePersistField)
-import GHC.Natural ( Natural )
+import Numeric.Natural ( Natural )
+import Text.Blaze (ToMarkup)
 import Text.Read (Read(readPrec), ReadPrec)
 import Web.Internal.HttpApiData
        (FromHttpApiData, ToHttpApiData, parseUrlPiece, toUrlPiece)
@@ -159,11 +160,13 @@ newtype Percent = Percent
              , Eq
              , FromHttpApiData
              , Generic
+             , Num
              , PersistField
              , PersistFieldSql
              , Read
              , Show
              , ToHttpApiData
+             , ToMarkup
              , Typeable
              )
 
@@ -177,10 +180,12 @@ newtype Price = Price
              , Eq
              , FromHttpApiData
              , Generic
+             , Num
              , PersistField
              , PersistFieldSql
              , Read
              , Show
+             , ToMarkup
              , ToHttpApiData
              , Typeable
              )

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -445,6 +445,14 @@ dbInsertCoupon email title couponType validFrom validUntil image discountPercent
       otherContent
       otherConditions
 
+dbFindCouponByEmailAndId
+  :: MonadKucipongDb m
+  => EmailAddress -> Key Coupon -> m (Maybe (Entity Coupon))
+dbFindCouponByEmailAndId email couponKey =
+  dbSelectFirstNotDeleted
+    [CouponStoreEmail ==. emailToStoreEmailKey email, CouponId ==. couponKey]
+    []
+
 dbFindCouponsByEmail
   :: MonadKucipongDb m
   => EmailAddress -> m [Entity Coupon]

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -445,6 +445,12 @@ dbInsertCoupon email title couponType validFrom validUntil image discountPercent
       otherContent
       otherConditions
 
+dbFindCouponsByEmail
+  :: MonadKucipongDb m
+  => EmailAddress -> m [Entity Coupon]
+dbFindCouponsByEmail email =
+  dbSelectList [CouponStoreEmail ==. emailToStoreEmailKey email] []
+
 -------------
 -- Helpers --
 -------------

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -15,7 +15,9 @@ import ClassyPrelude
 
 import Control.Monad.Logger (LoggingT, MonadLogger)
 import Control.Monad.Random (MonadRandom(..))
+import Numeric.Natural (Natural)
 import Language.Haskell.TH (Q, runIO)
+import Text.Blaze (Markup, ToMarkup(..), string)
 import Web.Spock (ActionCtxT)
 
 instance MonadRandom m =>
@@ -31,3 +33,7 @@ instance MonadLogger m =>
 instance MonadIO Q where
   liftIO :: IO a -> Q a
   liftIO = runIO
+
+instance ToMarkup Natural where
+  toMarkup :: Natural -> Markup
+  toMarkup = string . show

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -13,19 +13,21 @@ module Kucipong.Orphans where
 
 import ClassyPrelude
 
-import Control.Monad.Logger ( LoggingT, MonadLogger )
-import Control.Monad.Random ( MonadRandom(..) )
-import Language.Haskell.TH ( Q, runIO )
-import Web.Spock ( ActionCtxT )
+import Control.Monad.Logger (LoggingT, MonadLogger)
+import Control.Monad.Random (MonadRandom(..))
+import Language.Haskell.TH (Q, runIO)
+import Web.Spock (ActionCtxT)
 
-instance MonadRandom m => MonadRandom (LoggingT m) where
-    getRandom = lift getRandom
-    getRandomR = lift . getRandomR
-    getRandoms = lift getRandoms
-    getRandomRs = lift . getRandomRs
+instance MonadRandom m =>
+         MonadRandom (LoggingT m) where
+  getRandom = lift getRandom
+  getRandomR = lift . getRandomR
+  getRandoms = lift getRandoms
+  getRandomRs = lift . getRandomRs
 
-instance MonadLogger m => MonadLogger (ActionCtxT ctx m)
+instance MonadLogger m =>
+         MonadLogger (ActionCtxT ctx m)
 
 instance MonadIO Q where
-    liftIO :: IO a -> Q a
-    liftIO = runIO
+  liftIO :: IO a -> Q a
+  liftIO = runIO


### PR DESCRIPTION
Add /store/coupon GET handler for listing all coupons, and /store/coupon/\<id\>
handler for getting the details of an individual coupon.

The pug file `storeUser_store_coupon_id.html` (used in /store/coupon/\<id\>) has
not been finished yet.  It will be finished when we decide what to do about the
maybe and with control statements for hetercephalus:

https://github.com/arowM/heterocephalus/issues/9

If you go to http://localhost/store/coupon you will get a listing of all
coupons for a store.  If you click on a coupon you will get details about that
coupon.