### PR TITLE
Change the PORT environment variable for keter.

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,7 +29,7 @@ sudo apt-get -y install ufw postgresql
 
 ### Fire wall settings
 
-If you planning to run kucipong server on port `KUCIPONG_PORT`, open the port with [`ufw`](https://help.ubuntu.com/community/UFW).
+If you planning to run kucipong server on port `PORT`, open the port with [`ufw`](https://help.ubuntu.com/community/UFW).
 Also, make sure to open port for ssh.
 
 ### PostgreSQL settings

--- a/deploy/config/keter.yaml
+++ b/deploy/config/keter.yaml
@@ -3,7 +3,7 @@ stanzas:
     exec: ../kucipong
     host: 188.166.234.56
     env:
-      KUCIPONG_HOST: "188.166.234.56:8101"
+      KUCIPONG_HOST: "188.166.234.56"
       ENV: Production
     forward-env:
       - KUCIPONG_DB_PASSWORD

--- a/deploy/config/keter.yaml
+++ b/deploy/config/keter.yaml
@@ -1,5 +1,5 @@
 stanzas:
-  - type: background
+  - type: webapp
     exec: ../kucipong
     host: 188.166.234.56
     env:

--- a/src/Kucipong/Config.hs
+++ b/src/Kucipong/Config.hs
@@ -137,7 +137,7 @@ initKucipongSessionKey = fromEitherM handleErr . (initKey <=< decode)
 createConfigFromEnv :: IO Config
 createConfigFromEnv = do
   env <- readEnvVarDef "KUCIPONG_ENV" Development
-  port <- readEnvVarDef "KUCIPONG_PORT" 8101
+  port <- readEnvVarDef "PORT" 8101
   hailgunContextDomain <-
     lookupEnvDef
       "KUCIPONG_MAILGUN_DOMAIN"


### PR DESCRIPTION
I _believe_ keter expects the webapp to accept the `PORT` environment
variable in order to set the port the webapp is listening on.

Kucipong originally used the `KUCIPONG_PORT` environment variable instead
of the `PORT` environment variable.  This PR changes it so that Kucipong
uses the `PORT` environment variable so it works well with keter.

@arowM do you mind if I try releasing this onto the staging server?  I
haven't tested it locally, so I am not 100% sure it works.

Closes #94.