### PR TITLE
Fix errors with /store/coupon/create

### DIFF
--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -96,7 +96,7 @@ kucipongEntityDefs = [persistLowerCase|
         deleted                 DeletedTime Maybe
         title                   Text
         couponType              CouponType
-        validFrom               Day
+        validFrom               Day Maybe
         validUntil              Day Maybe
         image                   Image Maybe
         discountPercent         Percent Maybe

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -91,7 +91,7 @@ instance FromForm StoreEditForm
 data StoreNewCouponForm = StoreNewCouponForm
   { title :: !Text
   , couponType :: CouponType
-  , validFrom :: !Day
+  , validFrom :: !(MaybeEmpty Day)
   , validUntil :: !(MaybeEmpty Day)
   , discountPercent :: !(MaybeEmpty Percent)
   , discountMinimumPrice :: !(MaybeEmpty Price)

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -86,7 +86,7 @@ couponPost = do
       email
       title
       couponType
-      validFrom
+      (view _Wrapped validFrom)
       (view _Wrapped validUntil)
       Nothing -- image
       (view _Wrapped discountPercent)
@@ -107,6 +107,7 @@ couponPost = do
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
       p <- params
+      $(logDebug) $ "params: " <> tshow p
       $(logDebug) $ "got following error in store couponPost handler: " <> errMsg
       let errors = [errMsg]
       $(renderTemplate "storeUser_store_coupon_id_edit.html" $

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -402,7 +402,7 @@ dbInsertCoupon
   => EmailAddress
   -> Text
   -> CouponType
-  -> Day
+  -> Maybe Day
   -> Maybe Day
   -> Maybe Image
   -> Maybe Percent


### PR DESCRIPTION
/store/coupon/create will produce errors when trying to submit a blank
form.

I fixed this by making the coupon `validFrom` date optional.  Coupons
are now not required to have a `validFrom` date.

Fixes #87.