### PR TITLE
Get coupon edit page

### DIFF
--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -147,6 +147,7 @@ library
                      , TupleSections
                      , TypeFamilies
                      , TypeOperators
+                     , ViewPatterns
   other-extensions:    QuasiQuotes
                      , TemplateHaskell
 
@@ -184,6 +185,7 @@ executable kucipong
                      , TupleSections
                      , TypeFamilies
                      , TypeOperators
+                     , ViewPatterns
   other-extensions:    QuasiQuotes
                      , TemplateHaskell
 
@@ -227,6 +229,7 @@ executable kucipong-add-admin
                      , TupleSections
                      , TypeFamilies
                      , TypeOperators
+                     , ViewPatterns
   other-extensions:    QuasiQuotes
                      , TemplateHaskell
 

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -170,6 +170,9 @@ newtype Percent = Percent
              , Typeable
              )
 
+percentToText :: Percent -> Text
+percentToText = tshow . unPercent
+
 -----------
 -- Price --
 -----------
@@ -189,6 +192,9 @@ newtype Price = Price
              , ToHttpApiData
              , Typeable
              )
+
+priceToText :: Price -> Text
+priceToText = tshow . unPrice
 
 ----------------------
 -- BusinessCategory --

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -42,4 +42,5 @@ ghcExtensions =
     , "-XTupleSections"
     , "-XTypeFamilies"
     , "-XTypeOperators"
+    , "-XViewPatterns"
     ]


### PR DESCRIPTION
This PR adds the GET /store/coupon/\<id\>/edit api.

This is for issue #77.
