### PR TITLE
Change price to natural and add I18N for CouponTypes

### DIFF
--- a/frontend/src/pug/storeUser_store_coupon_id_edit.pug
+++ b/frontend/src/pug/storeUser_store_coupon_id_edit.pug
@@ -53,14 +53,14 @@ include _layout
                 name="couponType"
                 value="\#{fromMaybe mempty couponType}"
               )
-                option(value="\#{couponTypeToText CouponTypeDiscount}")
-                  | 購入額から割引
-                option(value="\#{couponTypeToText CouponTypeGift}")
-                  | 購入者プレゼント
-                option(value="\#{couponTypeToText CouponTypeSet}")
-                  | 特別セット
-                option(value="\#{couponTypeToText CouponTypeOther}")
-                  | その他クーポン
+                option(value="\#{key CouponTypeDiscount}")
+                  | \#{label CouponTypeDiscount}
+                option(value="\#{key CouponTypeGift}")
+                  | \#{label CouponTypeGift}
+                option(value="\#{key CouponTypeSet}")
+                  | \#{label CouponTypeSet}
+                option(value="\#{key CouponTypeOther}")
+                  | \#{label CouponTypeOther}
 
 
           #js-couponDiscount.js-invisible

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -31,18 +31,12 @@ data CouponType
   deriving (Data, Eq, Generic, Read, Show, Typeable)
 
 couponTypeToText :: CouponType -> Text
-couponTypeToText CouponTypeDiscount = "discount"
-couponTypeToText CouponTypeGift = "gift"
-couponTypeToText CouponTypeSet = "set"
-couponTypeToText CouponTypeOther = "other"
+couponTypeToText = tshow
 
 couponTypeFromText :: Text -> Either Text CouponType
-couponTypeFromText "discount" = pure CouponTypeDiscount
-couponTypeFromText "gift" = pure CouponTypeGift
-couponTypeFromText "set" = pure CouponTypeSet
-couponTypeFromText "other" = pure CouponTypeOther
-couponTypeFromText text = Left $ "Tried to convert \"" <> text
-    <> "\"to coupon type, but failed."
+couponTypeFromText text =
+  fromMaybeOrM (readMay text) $
+  Left $ "Tried to convert \"" <> text <> "\" to coupon type, but failed."
 
 instance FromHttpApiData CouponType where
   parseUrlPiece :: Text -> Either Text CouponType

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -172,7 +172,7 @@ percentToText = tshow . unPercent
 -----------
 
 newtype Price = Price
-  { unPrice :: Int64
+  { unPrice :: Natural
   } deriving ( Data
              , Eq
              , FromHttpApiData

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -10,8 +10,9 @@ import Kucipong.I18n.Types (Lang(..))
 import Kucipong.Db (Store(..))
 import Kucipong.Db.Models.Base
        (BeautyDetail(..), BusinessCategory(..),
-        BusinessCategoryDetail(..), CommonDetail(..), FashionDetail(..),
-        GourmetDetail(..), GadgetDetail(..), TravelingDetail(..))
+        BusinessCategoryDetail(..), CommonDetail(..), CouponType(..),
+        FashionDetail(..), GourmetDetail(..), GadgetDetail(..),
+        TravelingDetail(..), foldAllBusinessCategoryDetail)
 import Kucipong.Handler.Admin.Types (AdminError(..), AdminMsg(..))
 import Kucipong.Handler.Store.Types (StoreError(..), StoreMsg(..))
 import Kucipong.Monad.Db.Class (StoreDeleteResult(..))
@@ -73,12 +74,7 @@ instance I18n BusinessCategory where
   label EnUS Beauty = "Beauty"
 
 instance I18n BusinessCategoryDetail where
-  label lang (GourmetDetail a) = label lang a
-  label lang (FashionDetail a) = label lang a
-  label lang (GadgetDetail a) = label lang a
-  label lang (TravelingDetail a) = label lang a
-  label lang (BeautyDetail a) = label lang a
-  label lang (CommonDetail a) = label lang a
+  label lang = foldAllBusinessCategoryDetail (Proxy :: Proxy I18n) (label lang)
 
 instance I18n GourmetDetail where
   label EnUS GourmetPizza = "Pizza"
@@ -103,3 +99,9 @@ instance I18n BeautyDetail where
 instance I18n CommonDetail where
   label EnUS CommonPoliteService = "Polite service"
   label EnUS CommonChainStore = "Chain store"
+
+instance I18n CouponType where
+  label EnUS CouponTypeDiscount = "Discount"
+  label EnUS CouponTypeGift = "Gift"
+  label EnUS CouponTypeSet = "Set"
+  label EnUS CouponTypeOther = "Other"


### PR DESCRIPTION
This PR makes the following two changes:

1)  commit ade7b02:

    Adds an `I18n` instance for `CouponType`.

    Change some of the pug files to use `label` to show the `couponType` value.

    This changes the way the `CouponType`s are stored in the database.  In order to get the server to load with this commit, you must delete all existing coupons:

    ```sh
    $ psql -U kucipong -d kucipong -h 127.0.0.1
    kucipong=> delete from coupon;
    ```

    Fixes #83.
2)  commit a97ef50:

    Changes `Price` from `Int64` to `Natural`.  Fixes #108.