### PR TITLE
User friendly coupon edit page

### DIFF
--- a/frontend/src/pug/storeUser_store_coupon_id_edit.pug
+++ b/frontend/src/pug/storeUser_store_coupon_id_edit.pug
@@ -53,13 +53,25 @@ include _layout
                 name="couponType"
                 value="\#{fromMaybe mempty couponType}"
               )
-                option(value="\#{key CouponTypeDiscount}")
+                option(
+                  value="\#{key CouponTypeDiscount}"
+                  #{isSelected couponType (key CouponTypeDiscount)}
+                )
                   | \#{label CouponTypeDiscount}
-                option(value="\#{key CouponTypeGift}")
+                option(
+                  value="\#{key CouponTypeGift}"
+                  #{isSelected couponType (key CouponTypeGift)}
+                )
                   | \#{label CouponTypeGift}
-                option(value="\#{key CouponTypeSet}")
+                option(
+                  value="\#{key CouponTypeSet}"
+                  #{isSelected couponType (key CouponTypeSet)}
+                )
                   | \#{label CouponTypeSet}
-                option(value="\#{key CouponTypeOther}")
+                option(
+                  value="\#{key CouponTypeOther}"
+                  #{isSelected couponType (key CouponTypeOther)}
+                )
                   | \#{label CouponTypeOther}
 
 

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -139,7 +139,7 @@ couponEditPost couponKey = do
       (view _Wrapped setOtherConditions)
       (view _Wrapped otherContent)
       (view _Wrapped otherConditions)
-  redirect $ renderRoute storeCouponR
+  redirect $ renderRoute storeCouponVarR couponKey
   where
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do


### PR DESCRIPTION
This PR makes coupon edit process more user friendly.

The fb40972 is commit to select current coupon type on editing page.
This closes #109.

The page redirected to after submitting coupon updates is changed from coupon list page to detail page of the coupon in commit  2505526.
This is because an assumption that store user would want to check how it looks after updating a coupon.