### PR TITLE
Put images on S3

### DIFF
--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -140,6 +140,7 @@ library
                      , NoImplicitPrelude
                      , NoMonomorphismRestriction
                      , OverloadedStrings
+                     , PackageImports
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards
@@ -178,6 +179,7 @@ executable kucipong
                      , NoImplicitPrelude
                      , NoMonomorphismRestriction
                      , OverloadedStrings
+                     , PackageImports
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards
@@ -222,6 +224,7 @@ executable kucipong-add-admin
                      , NoImplicitPrelude
                      , NoMonomorphismRestriction
                      , OverloadedStrings
+                     , PackageImports
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -44,6 +44,7 @@ library
                      , Kucipong.I18n.Instance
                      , Kucipong.I18n.Types
                      , Kucipong.LoginToken
+                     , Kucipong.Logger
                      , Kucipong.Monad
                      , Kucipong.Monad.Cookie
                      , Kucipong.Monad.Cookie.Class

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -46,6 +46,10 @@ library
                      , Kucipong.LoginToken
                      , Kucipong.Logger
                      , Kucipong.Monad
+                     , Kucipong.Monad.Aws
+                     , Kucipong.Monad.Aws.Class
+                     , Kucipong.Monad.Aws.Instance
+                     , Kucipong.Monad.Aws.Trans
                      , Kucipong.Monad.Cookie
                      , Kucipong.Monad.Cookie.Class
                      , Kucipong.Monad.Cookie.Instance
@@ -70,11 +74,13 @@ library
   build-depends:       base >= 4.7 && < 5
                      , aeson
                      , amazonka
+                     , amazonka-core
                      , amazonka-s3
                      , base64-bytestring
                      , blaze-markup
                      , classy-prelude
                      , clientsession
+                     , cryptonite
                      , data-default
                      , emailaddress
                      , envelope

--- a/src/Kucipong.hs
+++ b/src/Kucipong.hs
@@ -3,23 +3,24 @@ module Kucipong ( defaultMain ) where
 
 import Kucipong.Prelude
 
-import Database.Persist.Sql ( runSqlPool )
+import Database.Persist.Sql (runSqlPool)
 
 import Kucipong.Aws (createS3ImageBucket)
-import Kucipong.Config ( Config(..), createConfigFromEnv, setLoggerMiddleware )
-import Kucipong.Db ( doMigrations )
-import Kucipong.Handler ( app )
-import Kucipong.Logger ( runLogger )
+import Kucipong.Config
+       (Config(..), createConfigFromEnv, setLoggerMiddleware)
+import Kucipong.Db (doMigrations)
+import Kucipong.Handler (app)
+import Kucipong.Logger (runLogger)
 
 -- | Run the API.
 defaultMain :: IO ()
 defaultMain = do
-    config <- createConfigFromEnv
-    runLogger $ createS3ImageBucket
+  config <- createConfigFromEnv
+  runLogger $
+    createS3ImageBucket
       (configAwsRegion config)
       (configAwsEnv config)
       (configS3ImageBucketName config)
-    -- TODO: Probably shouldn't run migrations in production automatically.
-    runSqlPool doMigrations $ configPool config
-    let loggerMiddleware = setLoggerMiddleware config
-    app loggerMiddleware config
+  runSqlPool doMigrations $ configPool config
+  let loggerMiddleware = setLoggerMiddleware config
+  app loggerMiddleware config

--- a/src/Kucipong.hs
+++ b/src/Kucipong.hs
@@ -9,12 +9,13 @@ import Kucipong.Aws (createS3ImageBucket)
 import Kucipong.Config ( Config(..), createConfigFromEnv, setLoggerMiddleware )
 import Kucipong.Db ( doMigrations )
 import Kucipong.Handler ( app )
+import Kucipong.Logger ( runLogger )
 
 -- | Run the API.
 defaultMain :: IO ()
 defaultMain = do
     config <- createConfigFromEnv
-    createS3ImageBucket
+    runLogger $ createS3ImageBucket
       (configAwsRegion config)
       (configAwsEnv config)
       (configS3ImageBucketName config)

--- a/src/Kucipong/Aws.hs
+++ b/src/Kucipong/Aws.hs
@@ -11,6 +11,7 @@ module Kucipong.Aws
     , S3ImageBucketName(..)
     , HasS3ImageBucketName(..)
     , createS3ImageBucket
+    , getAwsBucketM
     ) where
 
 import Kucipong.Prelude
@@ -91,3 +92,6 @@ createS3ImageBucket awsRegion awsEnv s3ImageBucketName = do
 -- | Convert an 'S3ImageBucketName' to a 'BucketName'.
 s3ImageBucketNameToBucketName :: S3ImageBucketName -> BucketName
 s3ImageBucketNameToBucketName = BucketName . unS3ImageBucketName
+
+getAwsBucketM :: (HasS3ImageBucketName r, MonadReader r m) => m BucketName
+getAwsBucketM = reader $ s3ImageBucketNameToBucketName . getS3ImageBucketName

--- a/src/Kucipong/Aws.hs
+++ b/src/Kucipong/Aws.hs
@@ -28,6 +28,7 @@ import Network.AWS.S3
         createBucketConfiguration)
 import Network.HTTP.Types (Status(Status, statusCode))
 
+-- | Newtype wrapper around the S3 image bucket name.
 newtype S3ImageBucketName = S3ImageBucketName
   { unS3ImageBucketName :: Text
   } deriving (Data, Eq, Generic, IsString, Ord, Show, Typeable)
@@ -46,6 +47,14 @@ instance HasAwsRegion Region where
   getAwsRegion :: Region -> Region
   getAwsRegion = id
 
+-- | Given a 'Region' and an 'Env', try to create a bucket on S3 with the name
+-- 'S3ImageBucketName'.
+--
+-- Succeed if either the bucket has been successfully created, or the bucket
+-- already exists.
+--
+-- Fail with 'error' if the bucket could not be created.  This could happen for
+-- many reasons.  For example, because of no network connectivity.
 createS3ImageBucket
   :: (MonadBaseControl IO m, MonadIO m, MonadLogger m, MonadThrow m)
   => Region -> Env -> S3ImageBucketName -> m ()
@@ -79,5 +88,6 @@ createS3ImageBucket awsRegion awsEnv s3ImageBucketName = do
         "\" on aws: " <>
         show errResp
 
+-- | Convert an 'S3ImageBucketName' to a 'BucketName'.
 s3ImageBucketNameToBucketName :: S3ImageBucketName -> BucketName
 s3ImageBucketNameToBucketName = BucketName . unS3ImageBucketName

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -8,6 +8,7 @@ import Kucipong.Prelude
 data StoreError
   = StoreErrorBusinessCategoryDetailIncorrect
   | StoreErrorCouldNotSendEmail
+  | StoreErrorCouldNotUploadImage
   | StoreErrorNoImage
   | StoreErrorNoStoreEmail EmailAddress
   deriving (Show, Eq, Ord, Read)

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -57,6 +57,8 @@ instance I18n StoreError where
     "Business category details do not belong to the selected business category."
   label EnUS StoreErrorCouldNotSendEmail =
     "Could not send email. Please try again."
+  label EnUS StoreErrorCouldNotUploadImage =
+    "Could not upload image. Please try again."
   label EnUS StoreErrorNoImage =
     "Failed to upload image. Please try again."
   label EnUS (StoreErrorNoStoreEmail email) =

--- a/src/Kucipong/Logger.hs
+++ b/src/Kucipong/Logger.hs
@@ -1,0 +1,9 @@
+
+module Kucipong.Logger where
+
+import Kucipong.Prelude
+
+import Control.Monad.Logger (LoggingT, runStdoutLoggingT)
+
+runLogger :: MonadIO m => LoggingT m a -> m a
+runLogger = runStdoutLoggingT

--- a/src/Kucipong/Monad.hs
+++ b/src/Kucipong/Monad.hs
@@ -7,7 +7,6 @@ module Kucipong.Monad
 
 import Kucipong.Prelude
 
-import Control.Monad.Logger (runStdoutLoggingT)
 import Control.Monad.Random (MonadRandom)
 import Control.Monad.Time (MonadTime)
 import Control.Monad.Trans.Class (MonadTrans)
@@ -17,6 +16,7 @@ import Control.Monad.Trans.Control
 
 import Kucipong.Config (Config)
 import Kucipong.Errors (AppErr)
+import Kucipong.Logger (runLogger)
 import Kucipong.Monad.Cookie as X
 import Kucipong.Monad.Db as X
 import Kucipong.Monad.OtherInstances ()
@@ -147,5 +147,4 @@ instance MonadBaseControl IO KucipongM where
 -- | Run the 'KucipongM' monad stack.
 runKucipongM :: Config -> KucipongM a -> IO (Either AppErr a)
 runKucipongM config =
-  runStdoutLoggingT .
-  runExceptT . flip runReaderT config . runKucipongT . unKucipongM
+  runLogger . runExceptT . flip runReaderT config . runKucipongT . unKucipongM

--- a/src/Kucipong/Monad/Aws.hs
+++ b/src/Kucipong/Monad/Aws.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Kucipong.Monad.Aws ( module X ) where
+
+import Kucipong.Monad.Aws.Class as X
+import Kucipong.Monad.Aws.Instance as X ()
+import Kucipong.Monad.Aws.Trans as X

--- a/src/Kucipong/Monad/Aws/Class.hs
+++ b/src/Kucipong/Monad/Aws/Class.hs
@@ -1,0 +1,43 @@
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
+module Kucipong.Monad.Aws.Class where
+
+import Kucipong.Prelude
+
+import Control.Monad.Trans (MonadTrans)
+import Network.AWS (Error)
+import Web.Spock (ActionCtxT, UploadedFile)
+
+import Kucipong.Db (Image)
+import Kucipong.Monad.Cookie.Trans (KucipongCookieT)
+import Kucipong.Monad.Db.Trans (KucipongDbT)
+import Kucipong.Monad.SendEmail.Trans (KucipongSendEmailT)
+
+data FileUploadError
+  = AwsError Error
+  | FileReadError IOException
+  deriving (Generic, Show, Typeable)
+
+
+-- |
+-- Default implementations are used to easily derive instances for monads
+-- transformers that implement 'MonadTrans'.
+class Monad m => MonadKucipongAws m where
+  awsS3PutUploadedFile
+    :: UploadedFile
+    -> m (Either FileUploadError Image)
+  default awsS3PutUploadedFile
+    :: ( MonadKucipongAws n
+       , MonadTrans t
+       , m ~ t n
+       )
+    => UploadedFile -> t n (Either FileUploadError Image)
+  awsS3PutUploadedFile = lift . awsS3PutUploadedFile
+
+instance MonadKucipongAws m => MonadKucipongAws (ActionCtxT ctx m)
+instance MonadKucipongAws m => MonadKucipongAws (ExceptT e m)
+instance MonadKucipongAws m => MonadKucipongAws (IdentityT m)
+instance MonadKucipongAws m => MonadKucipongAws (KucipongCookieT m)
+instance MonadKucipongAws m => MonadKucipongAws (KucipongDbT m)
+instance MonadKucipongAws m => MonadKucipongAws (KucipongSendEmailT m)
+instance MonadKucipongAws m => MonadKucipongAws (ReaderT r m)

--- a/src/Kucipong/Monad/Aws/Instance.hs
+++ b/src/Kucipong/Monad/Aws/Instance.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Kucipong.Monad.Aws.Instance where
+
+import Kucipong.Prelude
+
+import Control.Exception.Lens (_IOException, trying)
+import Control.Lens ((&), (.~), view)
+import Control.Monad.Trans.Resource (MonadResource)
+import "cryptonite" Crypto.Hash (Digest, SHA256)
+import Network.AWS
+       (AWSRequest(..), Error, HasEnv(..), _Error, runAWS, send, toBody)
+import Network.AWS.Data (toText)
+import Network.AWS.Data.Crypto (hashSHA256)
+import Network.AWS.S3
+       (ObjectCannedACL(OPublicRead), ObjectKey(..), putObject, poACL)
+import System.FilePath (replaceExtension, takeExtension)
+import Web.Spock (UploadedFile(..))
+
+import Kucipong.Aws (HasS3ImageBucketName, getAwsBucketM)
+import Kucipong.Db (Image(..))
+import Kucipong.Monad.Aws.Class
+       (FileUploadError(..), MonadKucipongAws(..))
+import Kucipong.Monad.Aws.Trans (KucipongAwsT(..))
+
+instance ( HasEnv r
+         , HasS3ImageBucketName r
+         , MonadCatch m
+         , MonadIO m
+         , MonadReader r m
+         , MonadResource m
+         ) =>
+         MonadKucipongAws (KucipongAwsT m) where
+  awsS3PutUploadedFile :: UploadedFile
+                       -> KucipongAwsT m (Either FileUploadError Image)
+  awsS3PutUploadedFile uploadedFile = do
+    bucket <- getAwsBucketM
+    eitherFileContents <- readUploadedFileContents uploadedFile
+    case eitherFileContents of
+      Left exception -> pure . Left $ FileReadError exception
+      Right fileContents -> do
+        let s3FileName = toS3FileName uploadedFile fileContents
+            objectKey = ObjectKey s3FileName
+            reqBody = toBody fileContents
+        let putObjectReq =
+              putObject bucket objectKey reqBody & poACL .~ Just OPublicRead
+        bimap AwsError (const $ Image s3FileName) <$> runReq putObjectReq
+
+-- | Run an AWS request and return an 'Error'.
+runReq
+  :: (AWSRequest a, MonadResource m, HasEnv r, MonadReader r m)
+  => a -> m (Either Error (Rs a))
+runReq req = do
+  awsEnv <- reader (view environment)
+  runAWS awsEnv . trying _Error $ send req
+
+-- | Hash the contents of a 'ByteString'.
+hashFileContents :: ByteString -> Digest SHA256
+hashFileContents = hashSHA256
+
+-- | Read the contents of an 'UploadedFile'.  Catches all 'IOException'.
+readUploadedFileContents
+  :: (MonadCatch m, MonadIO m)
+  => UploadedFile -> m (Either IOException ByteString)
+readUploadedFileContents = trying _IOException . readFile . uf_tempLocation
+
+-- | Calculates the new file name.  It becomes the SHA256 hash of the uploaded
+-- file.  Also, take the file extension of the uploaded file and uses it for
+-- the extension of the new file name.
+toS3FileName :: UploadedFile -> ByteString -> Text
+toS3FileName UploadedFile {uf_name} fileContents =
+  let name = toText $ hashFileContents fileContents
+  in pack . replaceExtension (unpack name) . takeExtension $ unpack uf_name

--- a/src/Kucipong/Monad/Aws/Trans.hs
+++ b/src/Kucipong/Monad/Aws/Trans.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 
-module Kucipong.Monad.SendEmail.Trans where
+module Kucipong.Monad.Aws.Trans where
 
 import Kucipong.Prelude
 
@@ -12,7 +12,7 @@ import Control.Monad.Trans.Control
     , defaultLiftBaseWith, defaultRestoreM )
 import Control.Monad.Trans.Resource (MonadResource(..))
 
-newtype KucipongSendEmailT m a = KucipongSendEmailT { unKucipongSendEmailT :: IdentityT m a }
+newtype KucipongAwsT m a = KucipongAwsT { unKucipongAwsT :: IdentityT m a }
     deriving
         ( Applicative
         , Functor
@@ -29,22 +29,22 @@ newtype KucipongSendEmailT m a = KucipongSendEmailT { unKucipongSendEmailT :: Id
         , MonadTrans
         )
 
-runKucipongSendEmailT :: KucipongSendEmailT m a -> m a
-runKucipongSendEmailT = runIdentityT . unKucipongSendEmailT
+runKucipongAwsT :: KucipongAwsT m a -> m a
+runKucipongAwsT = runIdentityT . unKucipongAwsT
 
-instance MonadTransControl KucipongSendEmailT where
-    type StT KucipongSendEmailT a = a
-    liftWith f = lift (f runKucipongSendEmailT)
-    restoreT = KucipongSendEmailT . IdentityT
+instance MonadTransControl KucipongAwsT where
+    type StT KucipongAwsT a = a
+    liftWith f = lift (f runKucipongAwsT)
+    restoreT = KucipongAwsT . IdentityT
     {-# INLINABLE liftWith #-}
     {-# INLINABLE restoreT #-}
 
-instance (MonadBaseControl b m) => MonadBaseControl b (KucipongSendEmailT m) where
-    type StM (KucipongSendEmailT m) a = ComposeSt KucipongSendEmailT m a
+instance (MonadBaseControl b m) => MonadBaseControl b (KucipongAwsT m) where
+    type StM (KucipongAwsT m) a = ComposeSt KucipongAwsT m a
     liftBaseWith = defaultLiftBaseWith
     restoreM     = defaultRestoreM
     {-# INLINABLE liftBaseWith #-}
     {-# INLINABLE restoreM #-}
 
-instance MonadResource m => MonadResource (KucipongSendEmailT m) where
+instance MonadResource m => MonadResource (KucipongAwsT m) where
   liftResourceT = lift . liftResourceT

--- a/src/Kucipong/Monad/Cookie/Class.hs
+++ b/src/Kucipong/Monad/Cookie/Class.hs
@@ -7,6 +7,7 @@ import Kucipong.Prelude
 import Control.Monad.Trans ( MonadTrans )
 import Web.Spock ( ActionCtxT, CookieSettings )
 
+import Kucipong.Monad.Aws.Trans ( KucipongAwsT )
 import Kucipong.Monad.Db.Trans ( KucipongDbT )
 import Kucipong.Monad.SendEmail.Trans ( KucipongSendEmailT )
 import Kucipong.Session ( Admin, Session, Store )
@@ -58,6 +59,7 @@ class Monad m => MonadKucipongCookie m where
 instance MonadKucipongCookie m => MonadKucipongCookie (ActionCtxT ctx m)
 instance MonadKucipongCookie m => MonadKucipongCookie (ExceptT e m)
 instance MonadKucipongCookie m => MonadKucipongCookie (IdentityT m)
+instance MonadKucipongCookie m => MonadKucipongCookie (KucipongAwsT m)
 instance MonadKucipongCookie m => MonadKucipongCookie (KucipongDbT m)
 instance MonadKucipongCookie m => MonadKucipongCookie (KucipongSendEmailT m)
 instance MonadKucipongCookie m => MonadKucipongCookie (ReaderT r m)

--- a/src/Kucipong/Monad/Cookie/Trans.hs
+++ b/src/Kucipong/Monad/Cookie/Trans.hs
@@ -10,7 +10,7 @@ import Control.Monad.Trans.Class ( MonadTrans )
 import Control.Monad.Trans.Control
     ( ComposeSt, MonadBaseControl(..), MonadTransControl(..)
     , defaultLiftBaseWith, defaultRestoreM )
-
+import Control.Monad.Trans.Resource (MonadResource(..))
 
 newtype KucipongCookieT m a = KucipongCookieT { unKucipongCookieT :: IdentityT m a }
     deriving
@@ -45,3 +45,6 @@ instance (MonadBaseControl b m) => MonadBaseControl b (KucipongCookieT m) where
     restoreM     = defaultRestoreM
     {-# INLINABLE liftBaseWith #-}
     {-# INLINABLE restoreM #-}
+
+instance MonadResource m => MonadResource (KucipongCookieT m) where
+  liftResourceT = lift . liftResourceT

--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -14,6 +14,7 @@ import Kucipong.Db
        (Admin, AdminLoginToken, BusinessCategory(..),
         BusinessCategoryDetail(..), DbSafeError, Image, Key, Store,
         StoreEmail, StoreLoginToken)
+import Kucipong.Monad.Aws.Trans ( KucipongAwsT )
 import Kucipong.Monad.Cookie.Trans (KucipongCookieT)
 import Kucipong.Monad.SendEmail.Trans (KucipongSendEmailT)
 
@@ -241,6 +242,7 @@ class Monad m => MonadKucipongDb m where
 instance MonadKucipongDb m => MonadKucipongDb (ActionCtxT ctx m)
 instance MonadKucipongDb m => MonadKucipongDb (ExceptT e m)
 instance MonadKucipongDb m => MonadKucipongDb (IdentityT m)
+instance MonadKucipongDb m => MonadKucipongDb (KucipongAwsT m)
 instance MonadKucipongDb m => MonadKucipongDb (KucipongCookieT m)
 instance MonadKucipongDb m => MonadKucipongDb (KucipongSendEmailT m)
 instance MonadKucipongDb m => MonadKucipongDb (ReaderT r m)

--- a/src/Kucipong/Monad/Db/Trans.hs
+++ b/src/Kucipong/Monad/Db/Trans.hs
@@ -10,6 +10,7 @@ import Control.Monad.Trans.Class ( MonadTrans )
 import Control.Monad.Trans.Control
     ( ComposeSt, MonadBaseControl(..), MonadTransControl(..)
     , defaultLiftBaseWith, defaultRestoreM )
+import Control.Monad.Trans.Resource (MonadResource(..))
 
 newtype KucipongDbT m a = KucipongDbT { unKucipongDbT :: IdentityT m a }
     deriving
@@ -44,3 +45,6 @@ instance (MonadBaseControl b m) => MonadBaseControl b (KucipongDbT m) where
     restoreM     = defaultRestoreM
     {-# INLINABLE liftBaseWith #-}
     {-# INLINABLE restoreM #-}
+
+instance MonadResource m => MonadResource (KucipongDbT m) where
+  liftResourceT = lift . liftResourceT

--- a/src/Kucipong/Monad/SendEmail/Class.hs
+++ b/src/Kucipong/Monad/SendEmail/Class.hs
@@ -9,6 +9,7 @@ import Web.Spock ( ActionCtxT )
 
 import Kucipong.Email (EmailError)
 import Kucipong.LoginToken ( LoginToken )
+import Kucipong.Monad.Aws.Trans ( KucipongAwsT )
 import Kucipong.Monad.Cookie.Trans ( KucipongCookieT )
 import Kucipong.Monad.Db.Trans ( KucipongDbT )
 
@@ -43,6 +44,7 @@ class Monad m => MonadKucipongSendEmail m where
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ActionCtxT ctx m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ExceptT e m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (IdentityT m)
+instance MonadKucipongSendEmail m => MonadKucipongSendEmail (KucipongAwsT m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (KucipongCookieT m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (KucipongDbT m)
 instance MonadKucipongSendEmail m => MonadKucipongSendEmail (ReaderT r m)

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -16,10 +16,11 @@ import ClassyPrelude
 import Control.Monad.Logger (LoggingT, MonadLogger)
 import Control.Monad.Random (MonadRandom(..))
 import Control.Monad.Trans.Resource (ResourceT)
+import Data.Data (Data)
 import Numeric.Natural (Natural)
 import Language.Haskell.TH (Q, runIO)
 import Text.Blaze (Markup, ToMarkup(..), string)
-import Web.Spock (ActionCtxT)
+import Web.Spock (ActionCtxT, UploadedFile(..))
 
 instance MonadRandom m =>
          MonadRandom (LoggingT m) where
@@ -28,14 +29,14 @@ instance MonadRandom m =>
   getRandoms = lift getRandoms
   getRandomRs = lift . getRandomRs
 
-instance MonadLogger m =>
-         MonadLogger (ActionCtxT ctx m)
-
 instance MonadRandom m => MonadRandom (ResourceT m) where
   getRandom = lift getRandom
   getRandomR = lift . getRandomR
   getRandoms = lift getRandoms
   getRandomRs = lift . getRandomRs
+
+instance MonadLogger m =>
+         MonadLogger (ActionCtxT ctx m)
 
 instance MonadIO Q where
   liftIO :: IO a -> Q a
@@ -44,3 +45,7 @@ instance MonadIO Q where
 instance ToMarkup Natural where
   toMarkup :: Natural -> Markup
   toMarkup = string . show
+
+deriving instance Data UploadedFile
+deriving instance Show UploadedFile
+

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -15,6 +15,7 @@ import ClassyPrelude
 
 import Control.Monad.Logger (LoggingT, MonadLogger)
 import Control.Monad.Random (MonadRandom(..))
+import Control.Monad.Trans.Resource (ResourceT)
 import Numeric.Natural (Natural)
 import Language.Haskell.TH (Q, runIO)
 import Text.Blaze (Markup, ToMarkup(..), string)
@@ -29,6 +30,12 @@ instance MonadRandom m =>
 
 instance MonadLogger m =>
          MonadLogger (ActionCtxT ctx m)
+
+instance MonadRandom m => MonadRandom (ResourceT m) where
+  getRandom = lift getRandom
+  getRandomR = lift . getRandomR
+  getRandoms = lift getRandoms
+  getRandomRs = lift . getRandomRs
 
 instance MonadIO Q where
   liftIO :: IO a -> Q a

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -34,6 +34,7 @@ ghcExtensions =
     , "-XNoImplicitPrelude"
     , "-XNoMonomorphismRestriction"
     , "-XOverloadedStrings"
+    , "-XPackageImports"
     , "-XPolyKinds"
     , "-XRankNTypes"
     , "-XRecordWildCards"


### PR DESCRIPTION
This PR enables image uploading to AWS S3.

If you go to the store edit page (http://localhost:8101/store/edit), you can upload an image for the Store.  The image will be stored on S3 (https://console.aws.amazon.com/s3/home?region=us-east-1#&bucket=kucipong-images-dev&prefix=).

Here's an example image:

![sample image](https://s3-ap-northeast-1.amazonaws.com/kucipong-images-dev/e1988d9d8f20d5301ee16fc858d03556ce597155d9eb5e822e05ce8bc017f018.jpg)

This PR makes it a requirement to run the API with a valid AWS ACCESS KEY and SECRET KEY.  
@arowM If you want to change it (for instance, just disable S3 image uploading if no ACCESS KEY or SECRET KEY is available), let me know.

Also, this PR only implements image uploading for the store edit page.  I will add image uploading for coupons in a future PR.  Also, the images from S3 are currently not returned to user (on pages like /store).  I will add that in a future PR as well.