### PR TITLE
Fix the content type of uploaded images.

### DIFF
--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -220,6 +220,10 @@ storeEditPost = do
       $(logDebug) $ "got following aws error in storeEditPost handler: " <> tshow err
       $(logDebug) $ "uploaded file: " <> tshow uploadedFile
       handleErr $ label def StoreErrorCouldNotUploadImage
+    handleFileUploadError uploadedFile FileContentTypeError = do
+      $(logDebug) "got a content type error in storeEditPost handler."
+      $(logDebug) $ "uploaded file: " <> tshow uploadedFile
+      handleErr $ label def StoreErrorNotAnImage
     handleFileUploadError uploadedFile (FileReadError err) = do
       $(logDebug) $ "got following error trying to read the uploaded file " <>
         "in storeEditPost handler: " <> tshow err

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -11,6 +11,7 @@ data StoreError
   | StoreErrorCouldNotUploadImage
   | StoreErrorNoImage
   | StoreErrorNoStoreEmail EmailAddress
+  | StoreErrorNotAnImage
   deriving (Show, Eq, Ord, Read)
 
 data StoreMsg

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -63,6 +63,8 @@ instance I18n StoreError where
     "Failed to upload image. Please try again."
   label EnUS (StoreErrorNoStoreEmail email) =
     "Could not find store for email " <> tshow email <> "."
+  label EnUS StoreErrorNotAnImage =
+    "Uploaded file is not an image.  Please upload an image file."
 
 instance I18n StoreMsg where
   label EnUS StoreMsgSentVerificationEmail =

--- a/src/Kucipong/Monad/Aws/Class.hs
+++ b/src/Kucipong/Monad/Aws/Class.hs
@@ -15,9 +15,9 @@ import Kucipong.Monad.SendEmail.Trans (KucipongSendEmailT)
 
 data FileUploadError
   = AwsError Error
+  | FileContentTypeError
   | FileReadError IOException
   deriving (Generic, Show, Typeable)
-
 
 -- |
 -- Default implementations are used to easily derive instances for monads


### PR DESCRIPTION
This PR makes sure that files uploaded to S3 get their Content-type set correctly.

It also makes sure that only images will be uploaded to S3.  Other files will be rejected.

This is for #55.

Here's an example image:

https://s3-ap-northeast-1.amazonaws.com/kucipong-images-dev/e1988d9d8f20d5301ee16fc858d03556ce597155d9eb5e822e05ce8bc017f018.jpg

![example image](https://s3-ap-northeast-1.amazonaws.com/kucipong-images-dev/e1988d9d8f20d5301ee16fc858d03556ce597155d9eb5e822e05ce8bc017f018.jpg)

Here's the same image with a slightly different URL:

https://kucipong-images-dev.s3-ap-northeast-1.amazonaws.com/e1988d9d8f20d5301ee16fc858d03556ce597155d9eb5e822e05ce8bc017f018.jpg

![example image](https://kucipong-images-dev.s3-ap-northeast-1.amazonaws.com/e1988d9d8f20d5301ee16fc858d03556ce597155d9eb5e822e05ce8bc017f018.jpg)
