### PR TITLE
Show images on /store and /store/edit pages.

### DIFF
--- a/frontend/src/pug/storeUser_store.pug
+++ b/frontend/src/pug/storeUser_store.pug
@@ -9,7 +9,10 @@ include _layout
         a.btn.outerBtn(href="\#{renderRoute storeEditR}") 店舗情報編集
       header.storeHeader
         .annotatedImageGroup
-          img.annotatedImageGroup-image(src=require("../img/dummy.jpg") alt="\#{ name }")
+          img.annotatedImageGroup-image(
+            src="\#{fromMaybe mempty imageUrl}"
+            alt="\#{ name }"
+          )
           span.annotatedImageGroup-annotation 画像は一例です
         .highlightedBlock
           h2.highlightedBlock.storeHeader-title

--- a/frontend/src/pug/storeUser_store_edit.pug
+++ b/frontend/src/pug/storeUser_store_edit.pug
@@ -123,7 +123,9 @@ include _layout
                 input#storeImage(
                   name="image" type="file"
                 )
-                img.storeBody_info_body_row-body-image(src="./img/dummy.jpg")
+                img.storeBody_info_body_row-body-image(
+                  src="\#{fromMaybe mempty imageUrl}"
+                )
             .storeSubmit
               button.btn.outerBtn(type="submit")
                 | この内容で店舗情報を更新する

--- a/src/Kucipong/Monad/Aws/Class.hs
+++ b/src/Kucipong/Monad/Aws/Class.hs
@@ -34,6 +34,15 @@ class Monad m => MonadKucipongAws m where
     => UploadedFile -> t n (Either FileUploadError Image)
   awsS3PutUploadedFile = lift . awsS3PutUploadedFile
 
+  awsImageS3Url :: Image -> m Text
+  default awsImageS3Url
+    :: ( MonadKucipongAws n
+       , MonadTrans t
+       , m ~ t n
+       )
+    => Image -> t n Text
+  awsImageS3Url = lift . awsImageS3Url
+
 instance MonadKucipongAws m => MonadKucipongAws (ActionCtxT ctx m)
 instance MonadKucipongAws m => MonadKucipongAws (ExceptT e m)
 instance MonadKucipongAws m => MonadKucipongAws (IdentityT m)

--- a/src/Kucipong/Monad/Aws/Instance.hs
+++ b/src/Kucipong/Monad/Aws/Instance.hs
@@ -19,7 +19,8 @@ import Network.AWS.S3
 import System.FilePath (replaceExtension, takeExtension)
 import Web.Spock (UploadedFile(..))
 
-import Kucipong.Aws (HasS3ImageBucketName, getAwsBucketM)
+import Kucipong.Aws
+       (HasS3ImageBucketName(..), S3ImageBucketName(..), getAwsBucketM)
 import Kucipong.Db (Image(..))
 import Kucipong.Monad.Aws.Class
        (FileUploadError(..), MonadKucipongAws(..))
@@ -48,6 +49,12 @@ instance ( HasEnv r
               & poACL .~ Just OPublicRead
               & poContentType .~ Just contentType
       const (Image s3FileName) <$> runReq putObjectReq
+
+  awsImageS3Url :: Image -> KucipongAwsT m Text
+  awsImageS3Url (Image s3FileName) = do
+    (S3ImageBucketName bucketName) <- reader getS3ImageBucketName
+    let path = bucketName <> "/" <> s3FileName
+    pure $ "https://s3-ap-northeast-1.amazonaws.com/" <> path
 
 -- | Run an AWS request and return an 'Error'.
 runReq


### PR DESCRIPTION
This PR returns the image url on the http://localhost:8101/store and http://localhost:8101/store/edit pages.

If you go to http://localhost:8101/store/edit and upload an image, you will be able to see it when you go to http://localhost:8101/store and http://localhost:8101/store/edit 

This is for #55.

Note: Images are still not being handled for coupons.  That will happen on a future PR.