### PR TITLE
User friendly image selector

### DIFF
--- a/frontend/src/js/storeUser_store_edit.js
+++ b/frontend/src/js/storeUser_store_edit.js
@@ -46,13 +46,14 @@ mapFrame.addEventListener('load', function () {
 
 // On click add/delete image button.
 var uploadBtn = document.getElementById('storeImageLabel');
-var shouldUpdate = document.getElementById('storeImageShouldUpdate');
+// This field holds original image information.
+var defaultImage = document.getElementById('defaultImage');
 uploadBtn.addEventListener('click', function (eve) {
   if (uploadBtn.getAttribute('for') === 'storeImageSelector') {
     return;
   }
   uploadBtn.setAttribute('for', 'storeImageSelector');
-  shouldUpdate.value = 'true';
+  defaultImage.removeAttribute('name');
   eve.preventDefault();
 }, false);
 

--- a/frontend/src/js/storeUser_store_edit.js
+++ b/frontend/src/js/storeUser_store_edit.js
@@ -39,3 +39,36 @@ mapFrame.addEventListener('load', function () {
   mapFrameWrapper.removeAttribute('aria-busy');
   mapFrame.removeAttribute('aria-hidden');
 });
+
+/* ======================
+ *  Image uploader
+ * ====================== */
+
+// On click add/delete image button.
+var uploadBtn = document.getElementById('storeImageLabel');
+var shouldUpdate = document.getElementById('storeImageShouldUpdate');
+uploadBtn.addEventListener('click', function (eve) {
+  if (uploadBtn.getAttribute('for') === 'storeImageSelector') {
+    return;
+  }
+  uploadBtn.setAttribute('for', 'storeImageSelector');
+  shouldUpdate.value = 'true';
+  eve.preventDefault();
+}, false);
+
+// On load new image.
+var selector = document.getElementById('storeImageSelector');
+var preview = document.getElementById('storeImage');
+selector.addEventListener('change', function (eve) {
+  var imgFiles = Array.prototype.slice.call(eve.target.files).filter(function (f) {
+    return f.type.match('image.*');
+  });
+  imgFiles.slice(0, 1).forEach(function (f) {
+    var reader = new FileReader();
+    reader.onload = function (e) {
+      preview.src = e.target.result;
+      uploadBtn.setAttribute('for', 'storeImage');
+    };
+    reader.readAsDataURL(f);
+  });
+}, false);

--- a/frontend/src/pug/storeUser_store_edit.pug
+++ b/frontend/src/pug/storeUser_store_edit.pug
@@ -128,8 +128,8 @@ include _layout
                   img#storeImage.uploaderImg.storeBody_info_body_row-body-image(
                     src="\#{fromMaybe mempty imageUrl}"
                   )
-                  input#storeImageShouldUpdate(
-                    name="updateImage" type="hidden" value="false"
+                  input#defaultImage(
+                    name="defaultImage" type="hidden" value="\#{fromMaybe mempty defaultImage}"
                   )
             .storeSubmit
               button.btn.outerBtn(type="submit")

--- a/frontend/src/pug/storeUser_store_edit.pug
+++ b/frontend/src/pug/storeUser_store_edit.pug
@@ -120,12 +120,17 @@ include _layout
               .storeBody_info_body_row-header
                 | 店舗イメージ画像
               .storeBody_info_body_row-body
-                input#storeImage(
-                  name="image" type="file"
-                )
-                img.storeBody_info_body_row-body-image(
-                  src="\#{fromMaybe mempty imageUrl}"
-                )
+                .uploaderWrapper
+                  input#storeImageSelector.uploaderCore(
+                    name="image" type="file" accept="image/*"
+                  )
+                  label#storeImageLabel.uploaderLabel(for="storeImage")
+                  img#storeImage.uploaderImg.storeBody_info_body_row-body-image(
+                    src="\#{fromMaybe mempty imageUrl}"
+                  )
+                  input#storeImageShouldUpdate(
+                    name="updateImage" type="hidden" value="false"
+                  )
             .storeSubmit
               button.btn.outerBtn(type="submit")
                 | この内容で店舗情報を更新する

--- a/frontend/src/styles/_upload.scss
+++ b/frontend/src/styles/_upload.scss
@@ -1,0 +1,71 @@
+$base-size: 4.5em;
+$line-width: 0.1;
+$line-length: 0.8;
+$line-color: #fff;
+$background-color: #ff5858;
+$background-color2: #07b8eb;
+$easeInOutBack: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+$white: #fff;
+
+.uploaderWrapper {
+  position: relative;
+  font-size: $base-size;
+  min-height: 1em;
+}
+
+.uploaderCore {
+  display: none;
+}
+
+.uploaderImg {
+  max-height: 200vh;
+  transition: max-height 1.2s ease;
+}
+
+.uploaderLabel {
+  display: block;
+  height: 1em;
+  width: 1em;
+  border-radius: 50%;
+  background-color: $white;
+  color: black;
+  position: absolute;
+  top: 0;
+  left: calc(100% - 1em);
+  cursor: pointer;
+
+  &::before, &::after{
+    display: block;
+    content: '';
+    transform: rotate(-45deg);
+    background-color: $background-color;
+    position: absolute;
+    width: calc(#{$line-width} * 1em);
+    height: calc(#{$line-length} * 1em);
+    border-radius: calc(#{$line-width} * 1em / 2);
+    left: calc(1em / 2 - #{$line-width} * 1em / 2);
+    top: calc(1em / 2 - #{$line-length} * 1em / 2);
+  }
+
+  &::after {
+    transform: rotate(45deg);
+  }
+
+  &, &::before, &::after {
+    transition: all 0.8s $easeInOutBack 0.1s;
+  }
+
+  &[for="storeImageSelector"] {
+    transform: rotate(-45deg);
+    left:0;
+    background-color: $background-color2;
+
+    &::before, &::after {
+      background-color: $white;
+    }
+
+    & ~ .uploaderImg {
+      max-height: 0;
+    }
+  }
+}

--- a/frontend/src/styles/storeUser.scss
+++ b/frontend/src/styles/storeUser.scss
@@ -1,5 +1,6 @@
 @import "common";
 @import "loading";
+@import "upload";
 
 .store {
   .storeSubmit {

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -80,6 +80,7 @@ data StoreEditForm = StoreEditForm
   , businessHours :: !(Maybe Text)
   , regularHoliday :: !(Maybe Text)
   , url :: !(Maybe Text)
+  , defaultImage :: !(Maybe Text)
   } deriving (Data, Eq, Generic, Read, Show, Typeable)
 
 instance FromForm StoreEditForm


### PR DESCRIPTION
This PR makes it user friendly to select store image on `/store/edit` page.
This is part of #61.

* Commit 8e39a3a adds a feature to preview selected image
* Commit 28c0e25 adds an API field to reuse current image