### PR TITLE
Show images for coupons

### DIFF
--- a/frontend/src/pug/_couponSimple.pug
+++ b/frontend/src/pug/_couponSimple.pug
@@ -1,7 +1,10 @@
 .couponSimple
   a.card(href="\#{renderRoute storeCouponVarR couponKey}")
     .annotatedImageGroup
-      img.annotatedImageGroup-image(src=require("../img/dummy.jpg") alt="\#{ couponTitle coupon }")
+      img.annotatedImageGroup-image(
+        src="\#{ fromMaybe mempty (awsImageUrlFunc (couponImage coupon))}"
+        alt="\#{ couponTitle coupon }"
+      )
       span.annotatedImageGroup-annotation 画像は一例です
     .card_body
       .couponSimple_abstraction

--- a/frontend/src/pug/_coupon_id.pug
+++ b/frontend/src/pug/_coupon_id.pug
@@ -9,7 +9,10 @@
           label.checkableIcon-icon(for="js-fav-3")
 
     .annotatedImageGroup
-      img.annotatedImageGroup-image(src=require("../img/dummy.jpg") alt="七輪焼き肉・安安")
+      img.annotatedImageGroup-image(
+        src="\#{fromMaybe mempty maybeImageUrl}"
+        alt="七輪焼き肉・安安"
+      )
       span.annotatedImageGroup-annotation 画像は一例です
     .card_body
       .card_body_title

--- a/frontend/src/pug/storeUser_store_coupon_id_edit.pug
+++ b/frontend/src/pug/storeUser_store_coupon_id_edit.pug
@@ -25,7 +25,9 @@ include _layout
                 name="image" type="file"
                 accept="image/*"
               )
-              img.labeledRow-body-image(src="./img/dummy.jpg")
+              img.labeledRow-body-image(
+                src="\#{fromMaybe mempty maybeImageUrl}"
+              )
 
           .labeledRow
             label.labeledRow-header(for="validFrom")

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -36,6 +36,7 @@ library
                      , Kucipong.Handler.Store
                      , Kucipong.Handler.Store.Coupon
                      , Kucipong.Handler.Store.Types
+                     , Kucipong.Handler.Store.Util
                      , Kucipong.Handler.Static
                      , Kucipong.Handler.Static.TH
                      , Kucipong.Host

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -36,7 +36,7 @@ import Kucipong.I18n (label)
 import Kucipong.LoginToken (LoginToken)
 import Kucipong.Monad
        (FileUploadError(..), MonadKucipongAws(..), MonadKucipongCookie,
-        MonadKucipongDb(..), MonadKucipongSendEmail(..),
+        MonadKucipongDb(..), MonadKucipongSendEmail(..), awsImageS3Url,
         dbFindStoreByEmail, dbFindStoreLoginToken, dbUpsertStore)
 import Kucipong.RenderTemplate
        (fromParams, renderTemplate, renderTemplateFromEnv)

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -6,14 +6,14 @@ module Kucipong.Handler.Store
 
 import Kucipong.Prelude
 
-import Control.FromSum (fromEitherOrM, fromMaybeM)
+import Control.FromSum (fromMaybeM)
 import Control.Monad.Time (MonadTime(..))
 import Data.Default (def)
 import Data.List (nub)
 import Data.HVect (HVect(..))
 import Database.Persist (Entity(..))
 import Web.Spock
-       (ActionCtxT, UploadedFile(..), files, getContext, params, prehook,
+       (ActionCtxT, UploadedFile(..), getContext, params, prehook,
         redirect, renderRoute)
 import Web.Spock.Core (SpockCtxT, get, post)
 
@@ -31,6 +31,7 @@ import Kucipong.Handler.Route
        (storeCouponR, storeEditR, storeLoginR, storeLoginVarR, storeR)
 import Kucipong.Handler.Store.Coupon (storeCouponComponent)
 import Kucipong.Handler.Store.Types (StoreError(..), StoreMsg(..))
+import Kucipong.Handler.Store.Util (uploadedImageToS3)
 import Kucipong.I18n (label)
 import Kucipong.LoginToken (LoginToken)
 import Kucipong.Monad
@@ -193,15 +194,11 @@ storeEditPost = do
                 , regularHoliday
                 , url
                 } <- getReqParamErr handleErr
-  filesHashMap <- files
-  let maybeUploadedFile = lookup "image" filesHashMap
-  s3ImageName <-
-    case maybeUploadedFile of
-      Just uploadedFile -> do
-        eitherS3ImageName <- awsS3PutUploadedFile uploadedFile
-        fromEitherOrM eitherS3ImageName $ handleFileUploadError uploadedFile
-      Nothing -> handleErr $ label def StoreErrorNoImage
   checkBusinessCategoryDetails businessCategory businessCategoryDetails
+  s3ImageName <-
+    uploadedImageToS3
+      (handleErr $ label def StoreErrorNoImage)
+      handleFileUploadError
   void $
     dbUpsertStore
       email

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -65,12 +65,18 @@ couponNewGet = do
 
 couponGet
   :: forall xs n m.
-     (ContainsStoreSession n xs, MonadIO m, MonadKucipongDb m)
+     ( ContainsStoreSession n xs
+     , MonadIO m
+     , MonadKucipongAws m
+     , MonadKucipongDb m
+     )
   => Key Coupon -> ActionCtxT (HVect xs) m ()
 couponGet couponKey = do
   (StoreSession email) <- getStoreEmail
   maybeCouponEntity <- dbFindCouponByEmailAndId email couponKey
   maybeStoreEntity <- dbFindStoreByEmail email
+  let maybeImage = couponImage . entityVal =<< maybeCouponEntity
+  maybeImageUrl <- traverse awsImageS3Url maybeImage
   $(renderTemplateFromEnv "storeUser_store_coupon_id.html")
 
 couponEditGet

--- a/src/Kucipong/Handler/Store/Util.hs
+++ b/src/Kucipong/Handler/Store/Util.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Kucipong.Handler.Store.Util
+  where
+
+import Kucipong.Prelude
+
+import Control.FromSum (fromEitherOrM, fromMaybeM)
+import Data.HVect (HVect(..))
+import Web.Spock (ActionCtxT, UploadedFile(..), files)
+
+import Kucipong.Db (Image(..))
+import Kucipong.Monad (FileUploadError(..), MonadKucipongAws(..))
+
+uploadedImageToS3
+  :: forall xs m.
+     (MonadIO m, MonadKucipongAws m)
+  => (forall a. ActionCtxT (HVect xs) m a)
+  -- ^ Error handler for when the @\"image\"@ isn't uploaded.
+  -> (forall a. UploadedFile -> FileUploadError -> ActionCtxT (HVect xs) m a)
+  -- ^ Error handler for when an error occurs in the 'awsS3PutUploadedFile'
+  -- call.
+  -> ActionCtxT (HVect xs) m Image
+uploadedImageToS3 noImageHandler uploadErrorHandler = do
+  filesHashMap <- files
+  uploadedFile <- fromMaybeM noImageHandler $ lookup "image" filesHashMap
+  eitherS3ImageName <- awsS3PutUploadedFile uploadedFile
+  fromEitherOrM eitherS3ImageName $ uploadErrorHandler uploadedFile

--- a/src/Kucipong/Monad/Aws/Class.hs
+++ b/src/Kucipong/Monad/Aws/Class.hs
@@ -53,7 +53,10 @@ instance MonadKucipongAws m => MonadKucipongAws (KucipongSendEmailT m)
 instance MonadKucipongAws m => MonadKucipongAws (ReaderT r m)
 
 awsImageS3Url :: MonadKucipongAws m => Image -> m Text
-awsImageS3Url (Image s3FileName) = do
-  (S3ImageBucketName bucketName) <- awsGetBucketName
-  let path = bucketName <> "/" <> s3FileName
-  pure $ "https://s3-ap-northeast-1.amazonaws.com/" <> path
+awsImageS3Url image = do
+  bucketName <- awsGetBucketName
+  pure $ awsUrlFromImageAndBucket bucketName image
+
+awsUrlFromImageAndBucket :: S3ImageBucketName -> Image -> Text
+awsUrlFromImageAndBucket (S3ImageBucketName bucketName) (Image s3FileName) =
+  "https://s3-ap-northeast-1.amazonaws.com/" <> bucketName <> "/" <> s3FileName

--- a/src/Kucipong/Monad/Aws/Instance.hs
+++ b/src/Kucipong/Monad/Aws/Instance.hs
@@ -50,11 +50,9 @@ instance ( HasEnv r
               & poContentType .~ Just contentType
       const (Image s3FileName) <$> runReq putObjectReq
 
-  awsImageS3Url :: Image -> KucipongAwsT m Text
-  awsImageS3Url (Image s3FileName) = do
-    (S3ImageBucketName bucketName) <- reader getS3ImageBucketName
-    let path = bucketName <> "/" <> s3FileName
-    pure $ "https://s3-ap-northeast-1.amazonaws.com/" <> path
+  awsGetBucketName :: KucipongAwsT m S3ImageBucketName
+  awsGetBucketName = reader getS3ImageBucketName
+
 
 -- | Run an AWS request and return an 'Error'.
 runReq


### PR DESCRIPTION
This PR enables images for coupons.

Images for coupons can now be uploaded to S3 from `/store/coupon` POST and `/store/coupon/\<id\>/edit` POST.

Images for coupons can be viewed on `/store/coupon/\<id\>` GET, `/store/coupon/\<id\>/edit` GET.

There is one problem with this PR.  `/store/coupon/create` GET shows a form that lets the user upload a new coupon.  If this fails when posting to `/store/coupon` POST, `/store/coupon/create` is shown again, but the user's image will have been lost.

I don't think this is a huge problem, but it would be nice to fix it somehow.  Maybe we can add an issue for it an mark it low-priority.

This PR will probably conflict with #126.  If #126 is merged into master first, this PR will have to be updated before it can be cleanly merged into master.  Also, the functionality from #126 will have to be applied to the code in this PR as well.  @arowM if you want to do that in a future PR, feel free.  Otherwise I will do it.