### PR TITLE
Migrating from npm to yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: node_js
 
 # Caching so the next build will be fast too.
 cache:
+  yarn: true
   directories:
   - $HOME/.ghc
   - $HOME/.cabal
@@ -27,7 +28,7 @@ before_install:
 - unset CC
 
 # Download and unpack the stack executable
-- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH:$HOME/.yarn/bin
 - mkdir -p ~/.local/bin
 - |
   travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
@@ -42,17 +43,17 @@ before_install:
     echo 'jobs: $ncpus' >> $HOME/.cabal/config
   fi
 
-
 install:
+- curl -o- -L https://yarnpkg.com/install.sh | bash
+- ls "$HOME/.yarn/bin"
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
 - node --version
-- npm --version
+- yarn --version
 - if [ -f configure.ac ]; then autoreconf -i; fi
 - |
   set -ex
   cd frontend/
-  # TODO: We could try installing npm packages globally, and then cache that directory.
-  time npm install
+  time yarn install
   cd ../
   time stack --no-terminal --install-ghc test --bench --only-dependencies
   set +ex
@@ -61,7 +62,7 @@ script:
 - |
   set -ex
   cd frontend/
-  time npm run build
+  time yarn run build
   cd ../
   # TODO: haddock fails with ghc-8.0.1.  Reenable haddock when we get lts-8.
   time travis_wait 30 stack --no-terminal test --bench --no-run-benchmarks # --haddock --no-haddock-deps

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,17 +1,15 @@
-.PHONY: build clean npm-install watch
+.PHONY: build clean yarn-install watch
 all: build
 
-build: npm-install
-	npm run build
+build: yarn-install
+	yarn run build
 
 clean:
 	rm -rf dist
 
-npm-install:
-	if [ ! -d "node_modules" ] ; then \
-		npm install ; \
-	fi
+yarn-install:
+	yarn install
 
-watch: npm-install
-	npm start
+watch: yarn-install
+	yarn start
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,12 +4,12 @@ This directory provise static page templates for Kucipong.
 
 ## Requirements
 
-* npm (>= 2.15.8)
+* yarn (>= 0.20.3)
 
 ## Build templates
 
-Do `npm i && GOOGLE_MAP_API_KEY="${google_map_api_key}" npm run build` and you can get compiled files on `./dist`.
+Do `yarn && GOOGLE_MAP_API_KEY="${google_map_api_key}" yarn run build` and you can get compiled files on `./dist`.
 
 ## Development server
 
-Running `npm i && GOOGLE_MAP_API_KEY="${google_map_api_key}" npm start` starts development server that enables you auto reload on `localhost:8080`.
+Running `yarn && GOOGLE_MAP_API_KEY="${google_map_api_key}" yarn start` starts development server that enables you auto reload on `localhost:8080`.


### PR DESCRIPTION
This PR migrates front-end build tool from `npm` to [`yarn`](http://yarnpkg.com/).
It makes compile time and travis tests fast and secure.
@cdepillabout, please make sure to [install `yarn`](https://yarnpkg.com/en/docs/install) to build front-end files.