### PR TITLE
Allow store and coupons to be edited without requiring an image

### DIFF
--- a/frontend/src/js/storeUser_store_edit.js
+++ b/frontend/src/js/storeUser_store_edit.js
@@ -62,6 +62,7 @@ uploadBtn.addEventListener('click', function (eve) {
   selector.value = '';
   selector.type = '';
   selector.type = 'file';
+  selector.removeAttribute('name');
   eve.preventDefault();
 }, false);
 
@@ -73,6 +74,7 @@ resetBtn.addEventListener('click', function (eve) {
   selector.value = '';
   selector.type = '';
   selector.type = 'file';
+  selector.removeAttribute('name');
 }, false);
 
 // On load new image.
@@ -88,4 +90,5 @@ selector.addEventListener('change', function (eve) {
     };
     reader.readAsDataURL(f);
   });
+  selector.name = 'image';
 }, false);

--- a/frontend/src/pug/storeUser_store_edit.pug
+++ b/frontend/src/pug/storeUser_store_edit.pug
@@ -135,7 +135,7 @@ include _layout
               .storeBody_info_body_row-body
                 .uploaderWrapper
                   input#storeImageSelector.uploaderCore(
-                    name="image" type="file" accept="image/*"
+                    type="file" accept="image/*"
                   )
                   label#storeImageLabel.uploaderLabel(for="storeImage")
                   button.uploaderReset#resetImage(type="button")

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -107,6 +107,7 @@ data StoreNewCouponForm = StoreNewCouponForm
   , setOtherConditions :: !(MaybeEmpty Text)
   , otherContent :: !(MaybeEmpty Text)
   , otherConditions :: !(MaybeEmpty Text)
+  , defaultImage :: !(Maybe Text)
   } deriving (Data, Eq, Generic, Read, Show, Typeable)
 
 $(makeLensesFor
@@ -123,6 +124,7 @@ $(makeLensesFor
     , ("setOtherConditions", "setOtherConditionsLens")
     , ("otherContent", "otherContentLens")
     , ("otherConditions", "otherConditionsLens")
+    , ("defaultImage", "defaultImageLens")
     ]
     ''StoreNewCouponForm)
 

--- a/src/Kucipong/Handler/Store/Util.hs
+++ b/src/Kucipong/Handler/Store/Util.hs
@@ -5,24 +5,63 @@ module Kucipong.Handler.Store.Util
 
 import Kucipong.Prelude
 
-import Control.FromSum (fromEitherOrM, fromMaybeM)
 import Data.HVect (HVect(..))
 import Web.Spock (ActionCtxT, UploadedFile(..), files)
 
 import Kucipong.Db (Image(..))
 import Kucipong.Monad (FileUploadError(..), MonadKucipongAws(..))
 
-uploadedImageToS3
+-- uploadedImageToS3
+--   :: forall xs m.
+--      (MonadIO m, MonadKucipongAws m)
+--   => (forall a. ActionCtxT (HVect xs) m a)
+--   -- ^ Error handler for when the @\"image\"@ isn't uploaded.
+--   -> (forall a. UploadedFile -> FileUploadError -> ActionCtxT (HVect xs) m a)
+--   -- ^ Error handler for when an error occurs in the 'awsS3PutUploadedFile'
+--   -- call.
+--   -> ActionCtxT (HVect xs) m Image
+-- uploadedImageToS3 noImageHandler uploadErrorHandler = do
+--   filesHashMap <- files
+--   uploadedFile <- fromMaybeM noImageHandler $ lookup "image" filesHashMap
+--   eitherS3ImageName <- awsS3PutUploadedFile uploadedFile
+--   fromEitherOrM eitherS3ImageName $ uploadErrorHandler uploadedFile
+
+data UploadImgErr = UploadImgErr UploadedFile FileUploadError
+  deriving (Show, Typeable)
+
+-- | Upload the @\"image\"@ in 'files' to S3.  If the 'Maybe' 'Text' argument
+-- is 'Just', then use that as the 'Image' url and don't try to upload anything
+-- to S3.
+--
+-- The return type of this function is somewhat complex.
+--
+-- If the 'Maybe' 'Text' argument is 'Just', then that will be converted to an
+-- 'Image' and returned as an 'Right' ('Just' 'Image').
+--
+-- If the 'Maybe' 'Text' argument is 'Nothing', then the following will happen:
+--
+-- First, look for an uploaded file with a filename of @\"image\".  If it
+-- doesn't exist, then return 'Right' 'Nothing'.
+--
+-- If it does exist, then try to upload it to S3.
+--
+-- If it was successfully uploaded to S3, then return it's 'Image' url as
+-- 'Right' ('Just' 'Image').  If it failed to be uploaded, then return 'Left'
+-- 'UploadImgErr'.
+uploadImgToS3WithDef
   :: forall xs m.
      (MonadIO m, MonadKucipongAws m)
-  => (forall a. ActionCtxT (HVect xs) m a)
-  -- ^ Error handler for when the @\"image\"@ isn't uploaded.
-  -> (forall a. UploadedFile -> FileUploadError -> ActionCtxT (HVect xs) m a)
-  -- ^ Error handler for when an error occurs in the 'awsS3PutUploadedFile'
-  -- call.
-  -> ActionCtxT (HVect xs) m Image
-uploadedImageToS3 noImageHandler uploadErrorHandler = do
+  => Maybe Text -- ^ Default 'Image' url to use if 'Just'.  Not used if
+                -- 'Nothing'.
+  -> ActionCtxT (HVect xs) m (Either UploadImgErr (Maybe Image))
+uploadImgToS3WithDef (Just image) = pure . Right . Just $ Image image
+uploadImgToS3WithDef Nothing = do
   filesHashMap <- files
-  uploadedFile <- fromMaybeM noImageHandler $ lookup "image" filesHashMap
-  eitherS3ImageName <- awsS3PutUploadedFile uploadedFile
-  fromEitherOrM eitherS3ImageName $ uploadErrorHandler uploadedFile
+  case lookup "image" filesHashMap of
+    Nothing -> pure $ Right Nothing
+    Just uploadedFile -> do
+      eitherRes <- awsS3PutUploadedFile uploadedFile
+      either
+        (pure . Left . UploadImgErr uploadedFile)
+        (pure . Right . Just)
+        eitherRes


### PR DESCRIPTION
This PR allows the store owner to edit their store and coupons without requiring an image to be uploaded.

This effects the following pages:

- `/store/edit` POST
- `/store/coupon/create` POST
- `/store/coupon/\<id\>/edit` POST

Even after changing the Haskell code in commit a892c51, it still wasn't working quite right.  An image was always being uploaded even though I didn't have any image selected.

In commit c9388b2, I tried to change the javascript to make this work.  I think I got it working (for `/store/edit` POST only), but I'm not sure it's the best solution.  @arowM Can you take a look at this and let me know what you think?  If it looks alright, feel free to merge it in to master.  If not, let me know, or push a commit fixing it, etc.