### PR TITLE
Handle null and undefined images.

### DIFF
--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -148,6 +148,7 @@ library
                      , NoMonomorphismRestriction
                      , OverloadedStrings
                      , PackageImports
+                     , PatternSynonyms
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards
@@ -187,6 +188,7 @@ executable kucipong
                      , NoMonomorphismRestriction
                      , OverloadedStrings
                      , PackageImports
+                     , PatternSynonyms
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards
@@ -232,6 +234,7 @@ executable kucipong-add-admin
                      , NoMonomorphismRestriction
                      , OverloadedStrings
                      , PackageImports
+                     , PatternSynonyms
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -114,6 +114,7 @@ newtype Image = Image
   { unImage :: Text
   } deriving ( Data
              , Eq
+             , FromHttpApiData
              , FromJSON
              , Generic
              , Ord
@@ -121,6 +122,7 @@ newtype Image = Image
              , PersistFieldSql
              , Read
              , Show
+             , ToHttpApiData
              , ToJSON
              , Typeable
              )

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -18,7 +18,7 @@ import Web.HttpApiData (FromHttpApiData(..))
 
 import Kucipong.Db
        (BusinessCategory(..), BusinessCategoryDetail(..), CouponType(..),
-        Percent(..), Price(..))
+        Image(..), Percent(..), Price(..))
 
 newtype MaybeEmpty a = MaybeEmpty
   { unMaybeEmpty :: Maybe a
@@ -80,7 +80,7 @@ data StoreEditForm = StoreEditForm
   , businessHours :: !(Maybe Text)
   , regularHoliday :: !(Maybe Text)
   , url :: !(Maybe Text)
-  , defaultImage :: !(Maybe Text)
+  , defaultImage :: !(Maybe Image)
   } deriving (Data, Eq, Generic, Read, Show, Typeable)
 
 instance FromForm StoreEditForm
@@ -107,7 +107,7 @@ data StoreNewCouponForm = StoreNewCouponForm
   , setOtherConditions :: !(MaybeEmpty Text)
   , otherContent :: !(MaybeEmpty Text)
   , otherConditions :: !(MaybeEmpty Text)
-  , defaultImage :: !(Maybe Text)
+  , defaultImage :: !(Maybe Image)
   } deriving (Data, Eq, Generic, Read, Show, Typeable)
 
 $(makeLensesFor

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -35,6 +35,7 @@ ghcExtensions =
     , "-XNoMonomorphismRestriction"
     , "-XOverloadedStrings"
     , "-XPackageImports"
+    , "-XPatternSynonyms"
     , "-XPolyKinds"
     , "-XRankNTypes"
     , "-XRecordWildCards"


### PR DESCRIPTION
This PR allows images to be null or undefined.

Here is how the new logic works for uploading images:

If the `defaultImage` is null and the user has not uploaded an image, then the image will be removed from the store/coupon.

If the `defaultImage` is `""` and the user has not uploaded an image, then the image will be removed from the store/coupon.  (This might be caused by a bug on the image uploading functionality, but I decided to handle it anyway.  We can always remove functionality out later.)

If the `defaultImage` is some image name, and the user has not uploaded an image, then the `defaultImage` URL will be used as the store/coupon image name.

If the user has uploaded a file called `image`, it will be uploaded to S3, and the filename on S3 will be used as the store/coupon image name. 


Fixes #125 and fixes #137.