### PR TITLE
Combine store and store email tables

### DIFF
--- a/frontend/src/pug/_coupon_id.pug
+++ b/frontend/src/pug/_coupon_id.pug
@@ -2,7 +2,13 @@
 .coupon
   .card
     .card_header
-      h2.card_header_text \#{maybe "(no title)" (storeName . entityVal) maybeStoreEntity}
+      h2.card_header_text
+        | %{ case maybeStoreEntity }
+        | %{ of Just storeEntity }
+        | \#{fromMaybe "(no title)" (storeName (entityVal storeEntity))}
+        | %{ of Nothing }
+        | (no title)
+        | %{ endcase }
       .card_header_icon
         .icon.icon-fav.checkableIcon
           input#js-fav-3.checkableIcon-check.js-fav(type="checkbox" data-coupon-id="\#{fromSqlKey couponKey}")
@@ -110,7 +116,13 @@
       | No address is set
       | %{ endcase }
   .aboutStore
-    a.btn.outerBtn(href="\#{renderRoute storeR}") \#{maybe "(no title)" (storeName . entityVal) maybeStoreEntity}
+    a.btn.outerBtn(href="\#{renderRoute storeR}")
+      | %{ case maybeStoreEntity }
+      | %{ of Just storeEntity }
+      | \#{fromMaybe "(no title)" (storeName (entityVal storeEntity))}
+      | %{ of Nothing }
+      | (no title)
+      | %{ endcase }
   .moreContents
     | %{ case couponCouponType coupon }
     | %{ of CouponTypeDiscount }

--- a/frontend/src/pug/adminUser_admin_store_delete_confirm.pug
+++ b/frontend/src/pug/adminUser_admin_store_delete_confirm.pug
@@ -13,12 +13,12 @@ include _layout
           action="\#{renderRoute adminStoreDeleteR}"
         )
           .row
-            | 「\#{storeName}」を削除しますか？
+            | 「\#{fromMaybe "(no store name)" storeName}」を削除しますか？
           .labeledRow
             label.labeledRow-header(for="storeEmail")
 
               | 確認のため
-              span.strong \#{storeName}
+              span.strong \#{fromMaybe "(no store name)" storeName}
               | と入力してください
             .labeledRow-body
               input#storeName(

--- a/frontend/src/pug/adminUser_admin_store_delete_confirm.pug
+++ b/frontend/src/pug/adminUser_admin_store_delete_confirm.pug
@@ -22,9 +22,12 @@ include _layout
               | と入力してください
             .labeledRow-body
               input#storeName(
-                name="storeName" type="text"
-                required
+                name="storeName"
+                type="text"
               )
+          input#defaultImage(
+            name="storeEmail" type="hidden" value="\#{storeEmail}"
+                )
           .submitRow
             button.btn.outerBtn(type="submit")
               | この店舗ユーザを削除

--- a/frontend/src/pug/adminUser_admin_store_delete_confirm.pug
+++ b/frontend/src/pug/adminUser_admin_store_delete_confirm.pug
@@ -25,7 +25,7 @@ include _layout
                 name="storeName"
                 type="text"
               )
-          input#defaultImage(
+          input#storeEmail(
             name="storeEmail" type="hidden" value="\#{storeEmail}"
                 )
           .submitRow

--- a/frontend/src/pug/storeUser_store.pug
+++ b/frontend/src/pug/storeUser_store.pug
@@ -11,12 +11,12 @@ include _layout
         .annotatedImageGroup
           img.annotatedImageGroup-image(
             src="\#{fromMaybe mempty imageUrl}"
-            alt="\#{ name }"
+            alt!='\#{fromMaybe "(no name)" name}'
           )
           span.annotatedImageGroup-annotation 画像は一例です
         .highlightedBlock
           h2.highlightedBlock.storeHeader-title
-            | \#{ name }
+            | \#{fromMaybe "(no name)" name}
       .storeBody
         .storeBody_description
           p \#{ fromMaybe mempty salesPoint }
@@ -31,7 +31,7 @@ include _layout
               .storeBody_info_body_row-header
                 | カテゴリ
               .storeBody_info_body_row-body
-                | \#{ label businessCategory }
+                | \#{ label (fromMaybe Gourmet businessCategory) }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 店舗の特徴

--- a/frontend/src/pug/storeUser_store.pug
+++ b/frontend/src/pug/storeUser_store.pug
@@ -31,7 +31,7 @@ include _layout
               .storeBody_info_body_row-header
                 | カテゴリ
               .storeBody_info_body_row-body
-                | \#{ label (fromMaybe Gourmet businessCategory) }
+                | \#{ label (fromMaybe minBound businessCategory) }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 店舗の特徴

--- a/src/Kucipong/Db/Models.hs
+++ b/src/Kucipong/Db/Models.hs
@@ -30,11 +30,10 @@ emailToAdminKey :: EmailAddress -> Key Admin
 emailToAdminKey = AdminKey
 
 emailToStoreKey :: EmailAddress -> Key Store
-emailToStoreKey = StoreKey . StoreEmailKey
+emailToStoreKey = StoreKey
 
-emailToStoreEmailKey :: EmailAddress -> Key StoreEmail
-emailToStoreEmailKey = StoreEmailKey
-
+storeKeyToEmail :: Key Store -> EmailAddress
+storeKeyToEmail = unStoreKey
 
 -- | Type class for getting the 'EntityField' from a record responsible for the
 -- 'CreatedTime', 'DeletedTime', and 'UpdatedTime'.

--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -42,12 +42,12 @@ kucipongEntityDefs = [persistLowerCase|
         deriving Typeable
 
     Store json
-        storeEmail              StoreEmailId
+        email                   EmailAddress
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe
-        name                    Text
-        businessCategory        BusinessCategory
+        name                    Text Maybe
+        businessCategory        BusinessCategory Maybe
         businessCategoryDetails [BusinessCategoryDetail]
         image                   Image Maybe
         salesPoint              Text Maybe
@@ -57,18 +57,6 @@ kucipongEntityDefs = [persistLowerCase|
         regularHoliday          Text Maybe
         url                     Text Maybe
 
-        Primary storeEmail
-
-        deriving Eq
-        deriving Show
-        deriving Typeable
-
-    StoreEmail
-        email                   EmailAddress
-        created                 CreatedTime
-        updated                 UpdatedTime
-        deleted                 DeletedTime Maybe
-
         Primary email
 
         deriving Eq
@@ -76,21 +64,21 @@ kucipongEntityDefs = [persistLowerCase|
         deriving Typeable
 
     StoreLoginToken
-        email                   StoreEmailId
+        storeEmail              StoreId
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe
         loginToken              LoginToken
         expirationTime          LoginTokenExpirationTime
 
-        Primary email
+        Primary storeEmail
 
         deriving Eq
         deriving Show
         deriving Typeable
 
     Coupon
-        storeEmail              StoreEmailId
+        storeEmail              StoreId
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -71,8 +71,8 @@ data StoreLoginForm = StoreLoginForm
 instance FromForm StoreLoginForm
 
 data StoreEditForm = StoreEditForm
-  { name :: !Text
-  , businessCategory :: !BusinessCategory
+  { name :: !(Maybe Text)
+  , businessCategory :: !(Maybe BusinessCategory)
   , businessCategoryDetails :: ![BusinessCategoryDetail]
   , salesPoint :: !(Maybe Text)
   , address :: !(Maybe Text)

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -4,23 +4,22 @@ module Kucipong.Handler.Admin where
 
 import Kucipong.Prelude
 
-import Control.FromSum (fromEitherM, fromMaybeM, fromMaybeOrM)
+import Control.FromSum (fromMaybeM, fromMaybeOrM)
 import Control.Monad.Time (MonadTime(..))
 import Data.Default (def)
 import Data.HVect (HVect(..))
 import Database.Persist (Entity(..))
 import Network.HTTP.Types (forbidden403)
-import Text.Heterocephalus (overwrite)
 import Web.Spock
        (ActionCtxT, getContext, redirect, renderRoute, setStatus)
 import Web.Spock.Core (SpockCtxT, get, post, prehook)
 
 import Kucipong.Db
-       (DbSafeError(..), Key(..), LoginTokenExpirationTime(..),
+       (Key(..), LoginTokenExpirationTime(..),
         AdminLoginToken(adminLoginTokenExpirationTime,
                         adminLoginTokenLoginToken),
-        Store(Store, storeName), StoreEmail(storeEmailEmail),
-        StoreLoginToken(storeLoginTokenLoginToken))
+        Store(Store, storeName),
+        StoreLoginToken(storeLoginTokenLoginToken), storeKeyToEmail)
 import Kucipong.Email (EmailError)
 import Kucipong.Form
        (AdminLoginForm(AdminLoginForm),
@@ -35,10 +34,10 @@ import Kucipong.I18n (label)
 import Kucipong.LoginToken (LoginToken)
 import Kucipong.Monad
        (MonadKucipongCookie, MonadKucipongDb(..),
-        MonadKucipongSendEmail(..), StoreDeleteResult(..), dbFindAdmin,
-        dbFindAdminLoginToken, dbFindStoreByEmail)
-import Kucipong.RenderTemplate
-       (renderTemplate, renderTemplateFromEnv)
+        MonadKucipongSendEmail(..), StoreDeleteResult(..),
+        dbCreateInitStore, dbFindAdmin, dbFindAdminLoginToken,
+        dbFindStoreByEmail)
+import Kucipong.RenderTemplate (renderTemplateFromEnv)
 import Kucipong.Session (Admin, Session(..))
 import Kucipong.Spock
        (ContainsAdminSession, getAdminCookie, getAdminEmail,
@@ -121,13 +120,13 @@ storeCreatePost
   => ActionCtxT (HVect xs) m ()
 storeCreatePost = do
   (AdminStoreCreateForm storeEmailParam) <- getReqParamErr handleErr
-  eitherStoreEmailEntity <- dbCreateStoreEmail storeEmailParam
-  (Entity storeEmailKey storeEmail) <-
-    fromEitherM handleCreateStoreFail eitherStoreEmailEntity
-  (Entity _ storeLoginToken) <- dbCreateStoreMagicLoginToken storeEmailKey
+  maybeStoreEntity <- dbCreateInitStore storeEmailParam
+  (Entity storeKey _) <-
+    fromMaybeM handleCreateStoreFail maybeStoreEntity
+  (Entity _ storeLoginToken) <- dbCreateStoreMagicLoginToken storeKey
   maybe (pure ()) handleSendEmailFail =<<
     sendStoreLoginEmail
-      (storeEmailEmail storeEmail)
+      (storeKeyToEmail storeKey)
       (storeLoginTokenLoginToken storeLoginToken)
   redirect $ renderRoute adminStoreCreateR
   where
@@ -137,11 +136,11 @@ storeCreatePost = do
         "got following error in admin storeCreatePost handler: " <> errMsg
       let errors = [errMsg]
       $(renderTemplateFromEnv "adminUser_admin_store_create.html")
-    handleCreateStoreFail :: DbSafeError -> ActionCtxT (HVect xs) m a
-    handleCreateStoreFail DbSafeUniquenessViolation =
+
+    handleCreateStoreFail :: ActionCtxT (HVect xs) m a
+    handleCreateStoreFail =
       handleErr $ label def AdminErrorStoreWithSameEmailExists
-    handleCreateStoreFail _ =
-      handleErr $ label def AdminErrorStoreCreateDbProblem
+
     handleSendEmailFail :: EmailError -> ActionCtxT (HVect xs) m a
     handleSendEmailFail emailError = do
       $(logDebug) $
@@ -165,8 +164,7 @@ storeDeleteConfirmPost = do
   maybeStoreEntity <- dbFindStoreByEmail storeEmailParam
   (Entity _ Store {storeName}) <-
     fromMaybeOrM maybeStoreEntity . handleErr $ label def AdminErrorNoStoreEmail
-  $(renderTemplate "adminUser_admin_store_delete_confirm.html" $
-    overwrite "storeName" [|storeName|])
+  $(renderTemplateFromEnv "adminUser_admin_store_delete_confirm.html")
   where
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
@@ -189,11 +187,9 @@ storeDeletePost = do
       let messages = [label def res]
       in $(renderTemplateFromEnv "adminUser_admin_store_create.html")
     res@(StoreDeleteErrDoesNotExist _) -> handleErr $ label def res
-    res@(StoreDeleteErrNameDoesNotMatch realStore _) ->
-      let storeName' = storeName realStore
-          errors = [label def res]
-      in $(renderTemplate "adminUser_admin_store_delete_confirm.html" $
-        overwrite "storeName" [|storeName'|])
+    res@(StoreDeleteErrNameDoesNotMatch Store {storeName} _) ->
+      let errors = [label def res]
+      in $(renderTemplateFromEnv "adminUser_admin_store_delete_confirm.html")
   where
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -47,7 +47,7 @@ instance I18n StoreDeleteResult where
   label EnUS StoreDeleteSuccess = "Successfully deleted store."
   label EnUS (StoreDeleteErrNameDoesNotMatch realStore given) =
     "Entered store name \"" <> given <> "\" does not match the real store name \"" <>
-    storeName realStore <>
+    fromMaybe "" (storeName realStore) <>
     "\"."
   label EnUS (StoreDeleteErrDoesNotExist email) =
     "Store with email address of \"" <> toText email <> "\" does not exist."

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -147,6 +147,9 @@ instance ( MonadBaseControl IO m
       -- database to the name the user passed in.
       --
       -- If the store name from the database is 'Nothing', and the name passed
+      -- in by the user is @(no store name)@, then delete the store.
+      --
+      -- If the store name from the database is 'Nothing', and the name passed
       -- in by the user is @\"\"@, then delete the store.
       --
       -- If the store name from the database is 'Nothing', and the name passed
@@ -169,6 +172,8 @@ instance ( MonadBaseControl IO m
         -> UTCTime
         -- ^ Current time.
         -> ReaderT SqlBackend m StoreDeleteResult
+      deleteBasedOnName Nothing "(no store name)" storeKey _ currTime =
+        doDelete storeKey currTime
       deleteBasedOnName Nothing "" storeKey _ currTime =
         doDelete storeKey currTime
       deleteBasedOnName Nothing nameFromUser _ store _ =

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -10,19 +10,18 @@ import Control.Monad.Time (MonadTime(..))
 import Database.Persist.Sql
        (Entity(..), Filter, PersistRecordBackend, PersistStoreRead,
         SelectOpt, SqlBackend, Update, (==.), (=.), get, insert,
-        insertEntity, repsert, selectFirst, selectList, update, updateGet,
-        updateWhere)
+        insertEntity, insertUnique, repsert, selectFirst, selectList,
+        update, updateGet, updateWhere)
 
 import Kucipong.Config (Config)
 import Kucipong.Db
        (Admin(..), AdminLoginToken(..), BusinessCategory(..),
         BusinessCategoryDetail(..), Coupon(..), CouponType(..),
-        CreatedTime(..), DeletedTime(..), DbSafeError(..), EntityField(..),
+        CreatedTime(..), DeletedTime(..), EntityField(..),
         EntityDateFields(..), Image, Key(..), LoginTokenExpirationTime(..),
-        Percent(..), Price(..), Store(..), StoreEmail(..),
-        StoreLoginToken(..), UpdatedTime(..), emailToAdminKey,
-        emailToStoreEmailKey, emailToStoreKey, runDb, runDbCurrTime,
-        runDbSafe)
+        Percent(..), Price(..), Store(..), StoreLoginToken(..),
+        UpdatedTime(..), emailToAdminKey, emailToStoreKey, runDb,
+        runDbCurrTime)
 import Kucipong.LoginToken (LoginToken, createRandomLoginToken)
 import Kucipong.Monad.Db.Class
        (MonadKucipongDb(..), StoreDeleteResult(..))
@@ -108,59 +107,7 @@ instance ( MonadBaseControl IO m
   -- ===========
   --  For Store
   -- ===========
-  dbCreateStore
-    :: Key StoreEmail
-      -- ^ 'Key' for the 'StoreEmail'
-    -> Text
-      -- ^ 'Store' name
-    -> BusinessCategory
-      -- ^ 'Store' category
-    -> [BusinessCategoryDetail]
-      -- ^ 'Store' category detail
-    -> Maybe Image
-      -- ^ 'Image' for the 'Store'
-    -> Maybe Text
-      -- ^ Sales Point for the 'Store'
-    -> Maybe Text
-      -- ^ Address for the 'Store'
-    -> Maybe Text
-      -- ^ Phone number for the 'Store'
-    -> Maybe Text
-      -- ^ Business hours for the 'Store'
-    -> Maybe Text
-      -- ^ Regular holiday for the 'Store'
-    -> Maybe Text
-      -- ^ url for the 'Store'
-    -> KucipongDbT m (Entity Store)
-  dbCreateStore storeEmailKey name category catdets image salesPoint address phoneNumber
-          businessHours regularHoliday url = lift go
-    where
-      go :: m (Entity Store)
-      go = do
-          currTime <- currentTime
-          let store =
-                  Store storeEmailKey (CreatedTime currTime)
-                      (UpdatedTime currTime) Nothing name category catdets
-                      image salesPoint address phoneNumber businessHours
-                      regularHoliday url
-          runDb $ repsertEntity (StoreKey storeEmailKey) store
-
-  dbCreateStoreEmail :: EmailAddress
-                     -> KucipongDbT m (Either DbSafeError (Entity StoreEmail))
-  dbCreateStoreEmail email = lift go
-    where
-      go :: m (Either DbSafeError (Entity StoreEmail))
-      go = do
-        currTime <- currentTime
-        let storeEmail =
-              StoreEmail
-                email
-                (CreatedTime currTime)
-                (UpdatedTime currTime)
-                Nothing
-        runDbSafe $ insertEntity storeEmail
-
-  dbCreateStoreMagicLoginToken :: Key StoreEmail
+  dbCreateStoreMagicLoginToken :: Key Store
                                -> KucipongDbT m (Entity StoreLoginToken)
   dbCreateStoreMagicLoginToken storeEmailKey = lift go
     where
@@ -192,12 +139,54 @@ instance ( MonadBaseControl IO m
           let storeKey = emailToStoreKey email
           maybeStore <- get storeKey
           case maybeStore of
-            Just store
-              | storeName store == name -> do
-                update storeKey [StoreDeleted =. Just (DeletedTime currTime)]
-                pure StoreDeleteSuccess
-              | otherwise -> pure $ StoreDeleteErrNameDoesNotMatch store name
             Nothing -> pure $ StoreDeleteErrDoesNotExist email
+            Just store ->
+              deleteBasedOnName (storeName store) name storeKey store currTime
+
+      -- | Delete the store after comparing the name of the store from the
+      -- database to the name the user passed in.
+      --
+      -- If the store name from the database is 'Nothing', and the name passed
+      -- in by the user is @\"\"@, then delete the store.
+      --
+      -- If the store name from the database is 'Nothing', and the name passed
+      -- in by the user is not @\"\"@, then return
+      -- 'StoreDeleteErrNameDoesNotMatch'.
+      --
+      -- If the store name from the database is 'Just', and the name matches
+      -- the name entered by the user, then delete the store.
+      --
+      -- If the store name from the database is 'Just', and it does not match
+      -- the name entered by the user, then return
+      -- 'StoreDeleteErrNameDoesNotMatch'.
+      deleteBasedOnName
+        :: Maybe Text
+        -- ^ Store name from the database.
+        -> Text
+        -- ^ Store name entered by the user.
+        -> Key Store
+        -> Store
+        -> UTCTime
+        -- ^ Current time.
+        -> ReaderT SqlBackend m StoreDeleteResult
+      deleteBasedOnName Nothing "" storeKey _ currTime =
+        doDelete storeKey currTime
+      deleteBasedOnName Nothing nameFromUser _ store _ =
+        pure $ StoreDeleteErrNameDoesNotMatch store nameFromUser
+      deleteBasedOnName (Just nameFromDb) nameFromUser storeKey store currTime
+        | nameFromDb == nameFromUser =
+          doDelete storeKey currTime
+        | otherwise =
+          pure $ StoreDeleteErrNameDoesNotMatch store nameFromUser
+
+      doDelete :: Key Store -> UTCTime -> ReaderT SqlBackend m StoreDeleteResult
+      doDelete storeKey currTime = do
+        update
+          storeKey
+          [ StoreDeleted =. Just (DeletedTime currTime)
+          , StoreUpdated =. UpdatedTime currTime
+          ]
+        pure StoreDeleteSuccess
 
 
   -- ======= --
@@ -225,6 +214,20 @@ instance ( MonadBaseControl IO m
         runDbCurrTime $ \currTime -> do
           let newRecord = recordCreator currTime
           insertEntity newRecord
+
+  dbInsertUnique
+    :: forall record.
+       (PersistRecordBackend record SqlBackend)
+    => (UTCTime -> record)
+    -> KucipongDbT m (Maybe (Entity record))
+  dbInsertUnique recordCreator = lift go
+    where
+      go :: m (Maybe (Entity record))
+      go =
+        runDbCurrTime $ \currTime -> do
+          let newRecord = recordCreator currTime
+          maybeKey <- insertUnique newRecord
+          pure $ fmap (\key -> Entity key newRecord) maybeKey
 
   dbSelectFirst
     :: forall record.
@@ -302,6 +305,17 @@ dbInsertWithTime recordCreator =
   dbInsert $ \currTime ->
     recordCreator (CreatedTime currTime) (UpdatedTime currTime) Nothing
 
+dbInsertUniqueWithTime
+  :: forall m record.
+     ( MonadKucipongDb m
+     , PersistRecordBackend record SqlBackend
+     )
+  => (CreatedTime -> UpdatedTime -> Maybe DeletedTime -> record)
+  -> m (Maybe (Entity record))
+dbInsertUniqueWithTime recordCreator =
+  dbInsertUnique $ \currTime ->
+    recordCreator (CreatedTime currTime) (UpdatedTime currTime) Nothing
+
 dbSelectFirstNotDeleted
   :: forall m record.
      ( EntityDateFields record
@@ -370,10 +384,69 @@ dbFindAdmin = dbFindByKeyNotDeleted . emailToAdminKey
 -- Store --
 -----------
 
+dbCreateStore
+  :: MonadKucipongDb m
+  => EmailAddress
+  -> Maybe Text
+    -- ^ 'Store' name
+  -> Maybe BusinessCategory
+    -- ^ 'Store' category
+  -> [BusinessCategoryDetail]
+    -- ^ 'Store' category detail
+  -> Maybe Image
+    -- ^ 'Image' for the 'Store'
+  -> Maybe Text
+    -- ^ Sales Point for the 'Store'
+  -> Maybe Text
+    -- ^ Address for the 'Store'
+  -> Maybe Text
+    -- ^ Phone number for the 'Store'
+  -> Maybe Text
+    -- ^ Business hours for the 'Store'
+  -> Maybe Text
+    -- ^ Regular holiday for the 'Store'
+  -> Maybe Text
+    -- ^ url for the 'Store'
+  -> m (Maybe (Entity Store))
+dbCreateStore email name category catdets image salesPoint address phoneNumber businessHours regularHoliday url =
+  dbInsertUniqueWithTime $ \created updated deleted ->
+    Store
+      email
+      created
+      updated
+      deleted
+      name
+      category
+      catdets
+      image
+      salesPoint
+      address
+      phoneNumber
+      businessHours
+      regularHoliday
+      url
+
+dbCreateInitStore
+  :: MonadKucipongDb m
+  => EmailAddress -> m (Maybe (Entity Store))
+dbCreateInitStore email =
+  dbCreateStore
+    email
+    Nothing
+    Nothing
+    []
+    Nothing
+    Nothing
+    Nothing
+    Nothing
+    Nothing
+    Nothing
+    Nothing
+
 dbFindStoreByEmail
   :: MonadKucipongDb m
   => EmailAddress -> m (Maybe (Entity Store))
-dbFindStoreByEmail = dbFindByKeyNotDeleted . StoreKey . StoreEmailKey
+dbFindStoreByEmail = dbFindByKeyNotDeleted . emailToStoreKey
 
 dbFindStoreLoginToken
   :: MonadKucipongDb m
@@ -384,8 +457,8 @@ dbFindStoreLoginToken loginToken =
 dbUpsertStore
   :: MonadKucipongDb m
   => EmailAddress
-  -> Text
-  -> BusinessCategory
+  -> Maybe Text
+  -> Maybe BusinessCategory
   -> [BusinessCategoryDetail]
   -> Maybe Image
   -> Maybe Text
@@ -398,7 +471,7 @@ dbUpsertStore
 dbUpsertStore email name businessCategory businessCategoryDetails image salesPoint address phoneNumber businessHours regularHoliday url =
   dbUpsertWithTime (emailToStoreKey email) $ \createdTime updatedTime deletedTime ->
     Store
-      (emailToStoreEmailKey email)
+      email
       createdTime
       updatedTime
       deletedTime
@@ -442,7 +515,7 @@ dbInsertCoupon
 dbInsertCoupon email title couponType validFrom validUntil image discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
   dbInsertWithTime $ \createdTime updatedTime deletedTime ->
     Coupon
-      (emailToStoreEmailKey email)
+      (emailToStoreKey email)
       createdTime
       updatedTime
       deletedTime
@@ -470,14 +543,14 @@ dbFindCouponByEmailAndId
   => EmailAddress -> Key Coupon -> m (Maybe (Entity Coupon))
 dbFindCouponByEmailAndId email couponKey =
   dbSelectFirstNotDeleted
-    [CouponStoreEmail ==. emailToStoreEmailKey email, CouponId ==. couponKey]
+    [CouponStoreEmail ==. emailToStoreKey email, CouponId ==. couponKey]
     []
 
 dbFindCouponsByEmail
   :: MonadKucipongDb m
   => EmailAddress -> m [Entity Coupon]
 dbFindCouponsByEmail email =
-  dbSelectList [CouponStoreEmail ==. emailToStoreEmailKey email] []
+  dbSelectList [CouponStoreEmail ==. emailToStoreKey email] []
 
 dbUpdateCoupon
   :: MonadKucipongDb m
@@ -504,7 +577,7 @@ dbUpdateCoupon
   -> m ()
 dbUpdateCoupon couponKey email title couponType validFrom validUntil image discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
   dbUpdateWithTime
-    [CouponId ==. couponKey, CouponStoreEmail ==. emailToStoreEmailKey email]
+    [CouponId ==. couponKey, CouponStoreEmail ==. emailToStoreKey email]
     [ CouponTitle =. title
     , CouponCouponType =. couponType
     , CouponValidFrom =. validFrom


### PR DESCRIPTION
This PR gets rid of the `store_email` table and just uses the `store` table.

It also fixes the error from #113 where the Admin user is not able to delete a Store user unless the Store user has already been verified.

If this PR gets merged in to `master`, then the following SQL commands must be run:

```sql
drop table coupon cascade;
drop table store_login_token cascade;
drop table store cascade;
drop table store_email cascade;
```

Commit 6aeb04e removes the store_email table.  This commit changes a lot so it is pretty messy.

Commit cf606df fixes the error with deleting the Store user.