### PR TITLE
Change Store to have an integer ID instead of an email address.

### DIFF
--- a/frontend/src/pug/adminUser_admin_store_delete_confirm.pug
+++ b/frontend/src/pug/adminUser_admin_store_delete_confirm.pug
@@ -26,7 +26,7 @@ include _layout
                 type="text"
               )
           input#storeEmail(
-            name="storeEmail" type="hidden" value="\#{storeEmail}"
+            name="storeEmail" type="hidden" value="\#{toText storeEmail}"
                 )
           .submitRow
             button.btn.outerBtn(type="submit")

--- a/src/Kucipong/Db/Models.hs
+++ b/src/Kucipong/Db/Models.hs
@@ -29,12 +29,6 @@ share [ mkPersist sqlSettings { mpsGenerateLenses = False }
 emailToAdminKey :: EmailAddress -> Key Admin
 emailToAdminKey = AdminKey
 
-emailToStoreKey :: EmailAddress -> Key Store
-emailToStoreKey = StoreKey
-
-storeKeyToEmail :: Key Store -> EmailAddress
-storeKeyToEmail = unStoreKey
-
 -- | Type class for getting the 'EntityField' from a record responsible for the
 -- 'CreatedTime', 'DeletedTime', and 'UpdatedTime'.
 --

--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -57,28 +57,26 @@ kucipongEntityDefs = [persistLowerCase|
         regularHoliday          Text Maybe
         url                     Text Maybe
 
-        Primary email
-
         deriving Eq
         deriving Show
         deriving Typeable
 
     StoreLoginToken
-        storeEmail              StoreId
+        storeId                 StoreId
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe
         loginToken              LoginToken
         expirationTime          LoginTokenExpirationTime
 
-        Primary storeEmail
+        Primary storeId
 
         deriving Eq
         deriving Show
         deriving Typeable
 
     Coupon
-        storeEmail              StoreId
+        storeId                 StoreId
         created                 CreatedTime
         updated                 UpdatedTime
         deleted                 DeletedTime Maybe

--- a/src/Kucipong/Handler/Consumer.hs
+++ b/src/Kucipong/Handler/Consumer.hs
@@ -18,7 +18,7 @@ import Kucipong.Handler.Route (consumerCouponVarR, storeR)
 import Kucipong.I18n (label)
 import Kucipong.Monad
        (MonadKucipongAws(..), MonadKucipongDb(..), awsImageS3Url,
-        dbFindByKey, dbFindPublicCouponById)
+        dbFindStoreByStoreKey, dbFindPublicCouponById)
 import Kucipong.RenderTemplate (renderTemplateFromEnv)
 
 couponGet
@@ -29,7 +29,7 @@ couponGet couponKey = do
   maybeCouponEntity <- dbFindPublicCouponById couponKey
   Entity _ coupon <-
     fromMaybeM (handleErr $ label def ConsumerErrorCouldNotFindCoupon) maybeCouponEntity
-  maybeStoreEntity <- dbFindByKey (couponStoreEmail coupon)
+  maybeStoreEntity <- dbFindStoreByStoreKey $ couponStoreId coupon
   let maybeImage = couponImage . entityVal =<< maybeCouponEntity
   maybeImageUrl <- traverse awsImageS3Url maybeImage
   -- TODO

--- a/src/Kucipong/Monad/Cookie/Class.hs
+++ b/src/Kucipong/Monad/Cookie/Class.hs
@@ -4,57 +4,57 @@ module Kucipong.Monad.Cookie.Class where
 
 import Kucipong.Prelude
 
-import Control.Monad.Trans ( MonadTrans )
-import Web.Spock ( ActionCtxT, CookieSettings )
+import Control.Monad.Trans (MonadTrans)
+import Web.Spock (ActionCtxT, CookieSettings)
 
-import Kucipong.Monad.Aws.Trans ( KucipongAwsT )
-import Kucipong.Monad.Db.Trans ( KucipongDbT )
-import Kucipong.Monad.SendEmail.Trans ( KucipongSendEmailT )
-import Kucipong.Session ( Admin, Session, Store )
+import Kucipong.Monad.Aws.Trans (KucipongAwsT)
+import Kucipong.Monad.Db.Trans (KucipongDbT)
+import Kucipong.Monad.SendEmail.Trans (KucipongSendEmailT)
+import Kucipong.Session (Admin, Session, Store)
 
 -- |
 -- Default implementations are used to easily derive instances for monads
 -- transformers that implement 'MonadTrans'.
 class Monad m => MonadKucipongCookie m where
-    cookieSettings
-        :: m CookieSettings
-    default cookieSettings
-        :: ( MonadKucipongCookie n
-           , MonadTrans t
-           , m ~ t n
-           )
-        => t n CookieSettings
-    cookieSettings = lift cookieSettings
+  cookieSettings
+    :: m CookieSettings
+  default cookieSettings
+    :: ( MonadKucipongCookie n
+       , MonadTrans t
+       , m ~ t n
+       )
+    => t n CookieSettings
+  cookieSettings = lift cookieSettings
 
-    encryptSessionCookie
-        :: Session sessionType -> m Text
-    default encryptSessionCookie
-        :: ( MonadKucipongCookie n
-           , MonadTrans t
-           , m ~ t n
-           )
-        => Session sessionType -> t n Text
-    encryptSessionCookie = lift . encryptSessionCookie
+  encryptSessionCookie
+    :: Session sessionType -> m Text
+  default encryptSessionCookie
+    :: ( MonadKucipongCookie n
+       , MonadTrans t
+       , m ~ t n
+       )
+    => Session sessionType -> t n Text
+  encryptSessionCookie = lift . encryptSessionCookie
 
-    decryptAdminSessionCookie
-        :: Text -> m (Maybe (Session Admin))
-    default decryptAdminSessionCookie
-        :: ( MonadKucipongCookie n
-           , MonadTrans t
-           , m ~ t n
-           )
-        => Text -> t n (Maybe (Session Admin))
-    decryptAdminSessionCookie  = lift . decryptAdminSessionCookie
+  decryptAdminSessionCookie
+    :: Text -> m (Maybe (Session Admin))
+  default decryptAdminSessionCookie
+    :: ( MonadKucipongCookie n
+       , MonadTrans t
+       , m ~ t n
+       )
+    => Text -> t n (Maybe (Session Admin))
+  decryptAdminSessionCookie  = lift . decryptAdminSessionCookie
 
-    decryptStoreSessionCookie
-        :: Text -> m (Maybe (Session Store))
-    default decryptStoreSessionCookie
-        :: ( MonadKucipongCookie n
-           , MonadTrans t
-           , m ~ t n
-           )
-        => Text -> t n (Maybe (Session Store))
-    decryptStoreSessionCookie  = lift . decryptStoreSessionCookie
+  decryptStoreSessionCookie
+    :: Text -> m (Maybe (Session Store))
+  default decryptStoreSessionCookie
+    :: ( MonadKucipongCookie n
+       , MonadTrans t
+       , m ~ t n
+       )
+    => Text -> t n (Maybe (Session Store))
+  decryptStoreSessionCookie  = lift . decryptStoreSessionCookie
 
 instance MonadKucipongCookie m => MonadKucipongCookie (ActionCtxT ctx m)
 instance MonadKucipongCookie m => MonadKucipongCookie (ExceptT e m)

--- a/src/Kucipong/Monad/Cookie/Instance.hs
+++ b/src/Kucipong/Monad/Cookie/Instance.hs
@@ -8,44 +8,45 @@ import Kucipong.Prelude
 import Web.Spock
     ( CookieSettings(..), CookieEOL(..), defaultCookieSettings )
 
-import Kucipong.Environment ( Environment(Production), HasEnv(getEnv) )
-import Kucipong.Monad.Cookie.Class ( MonadKucipongCookie(..) )
-import Kucipong.Monad.Cookie.Trans ( KucipongCookieT(..) )
+import Kucipong.Environment
+       (Environment(Production), HasEnv(getEnv))
+import Kucipong.Monad.Cookie.Class (MonadKucipongCookie(..))
+import Kucipong.Monad.Cookie.Trans (KucipongCookieT(..))
 import Kucipong.Session
-    ( Admin, HasSessionKey, Session(AdminSession, StoreSession), Store
-    , decryptSessionGeneric, encryptSession )
-import Kucipong.Util ( oneYear )
+       (Admin, HasSessionKey, Session, Store, decryptAdminSession,
+        decryptStoreSession, encryptSession)
+import Kucipong.Util (oneYear)
 
 instance
-    ( HasEnv r
-    , HasSessionKey r
-    , MonadIO m
-    , MonadReader r m
-    ) => MonadKucipongCookie (KucipongCookieT m) where
+  ( HasEnv r
+  , HasSessionKey r
+  , MonadIO m
+  , MonadReader r m
+  ) => MonadKucipongCookie (KucipongCookieT m) where
 
-    cookieSettings :: KucipongCookieT m CookieSettings
-    cookieSettings = do
-        env <- reader getEnv
-        case env of
-            Production -> pure develCookieSettings { cs_secure = True }
-            _ -> pure develCookieSettings
-      where
-        develCookieSettings :: CookieSettings
-        develCookieSettings = defaultCookieSettings
-            { cs_EOL = CookieValidFor oneYear
-            , cs_HTTPOnly = True
-            , cs_secure = False
-            , cs_domain = Nothing
-            , cs_path = Just "/"
-            }
+  cookieSettings :: KucipongCookieT m CookieSettings
+  cookieSettings = do
+    env <- reader getEnv
+    case env of
+      Production -> pure develCookieSettings { cs_secure = True }
+      _ -> pure develCookieSettings
+    where
+      develCookieSettings :: CookieSettings
+      develCookieSettings = defaultCookieSettings
+        { cs_EOL = CookieValidFor oneYear
+        , cs_HTTPOnly = True
+        , cs_secure = False
+        , cs_domain = Nothing
+        , cs_path = Just "/"
+        }
 
-    encryptSessionCookie :: Session sessionType -> KucipongCookieT m Text
-    encryptSessionCookie = lift . encryptSession
+  encryptSessionCookie :: Session sessionType -> KucipongCookieT m Text
+  encryptSessionCookie = lift . encryptSession
 
-    decryptAdminSessionCookie
-        :: Text -> KucipongCookieT m (Maybe (Session Admin))
-    decryptAdminSessionCookie = decryptSessionGeneric AdminSession
+  decryptAdminSessionCookie
+    :: Text -> KucipongCookieT m (Maybe (Session Admin))
+  decryptAdminSessionCookie = decryptAdminSession
 
-    decryptStoreSessionCookie
-        :: Text -> KucipongCookieT m (Maybe (Session Store))
-    decryptStoreSessionCookie = decryptSessionGeneric StoreSession
+  decryptStoreSessionCookie
+    :: Text -> KucipongCookieT m (Maybe (Session Store))
+  decryptStoreSessionCookie = decryptStoreSession


### PR DESCRIPTION
This PR changes the `store` table to have an integer ID instead of an email address.

This ends up affecting many different areas of the code base, but it is basically a mechanical transformation.

With this change, the Admin user can delete a `Store` and recreate another `Store` with the same email address.  This fixes #141.

In order to get this PR to run, you will probably have to run the following sql statements to drop the old `store` table.

```sql
drop table coupon cascade;
drop table store_login_token cascade;
drop table store cascade;
drop table store_email cascade;
```