### PR TITLE
prevent admin user from adding same store twice.

### DIFF
--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -86,6 +86,15 @@ class Monad m => MonadKucipongDb m where
       => Key Store -> t n (Entity StoreLoginToken)
   dbCreateStoreMagicLoginToken = lift . dbCreateStoreMagicLoginToken
 
+  dbCreateInitStore :: EmailAddress -> m (Maybe (Entity Store))
+  default dbCreateInitStore
+      :: ( MonadKucipongDb n
+         , MonadTrans t
+         , m ~ t n
+         )
+      => EmailAddress -> t n (Maybe (Entity Store))
+  dbCreateInitStore = lift . dbCreateInitStore
+
   dbDeleteStoreIfNameMatches
     :: EmailAddress
     -- ^ 'EmailAddress' for the 'Store'


### PR DESCRIPTION
This PR fixes the comment from https://github.com/blueimpact/kucipong/pull/147#issuecomment-287592861.

This PR adds functionality that prevents the admin user from adding a store with the same email address twice, unless all existing stores are already set as deleted.