### PR TITLE
Slim down template

### DIFF
--- a/frontend/src/endUser.js
+++ b/frontend/src/endUser.js
@@ -4,4 +4,6 @@
 
 require('./styles/endUser.scss');
 
+require('./js/_googleMap.js');
+
 Fav.view();

--- a/frontend/src/js/_googleMap.js
+++ b/frontend/src/js/_googleMap.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var maps = Array.prototype.slice.call(document.getElementsByClassName('js-googleMap') || []);
+
+maps.forEach(function (map) {
+  var apiKey = map.getAttribute('data-api-key');
+  var address = map.getAttribute('data-address');
+
+  if (!!address) {
+    map.setAttribute('src', "https://www.google.com/maps/embed/v1/place?key=" + apiKey + "&q=" + address);
+  }
+});

--- a/frontend/src/pug/_coupon_id.pug
+++ b/frontend/src/pug/_coupon_id.pug
@@ -50,7 +50,7 @@
   .annotation ※ この画面を店舗でご提示ください
   .location
     .location_map
-      .location_map-frame(
+      iframe.location_map-frame.js-googleMap(
         frameborder="0"
         allowfullscreen
         data-api-key=data.googleMapApiKey

--- a/frontend/src/pug/_coupon_id.pug
+++ b/frontend/src/pug/_coupon_id.pug
@@ -57,7 +57,7 @@
         data-address!="\#{format StoreAddress coupon}"
       )
   .aboutStore
-    a.btn.outerBtn(href="\#{renderRoute storeR}")
+    a.btn.outerBtn(href="\#{aboutStore}")
       | \#{format StoreName coupon}
   .moreContents
     | %{ case format CouponType coupon }

--- a/frontend/src/pug/_coupon_id.pug
+++ b/frontend/src/pug/_coupon_id.pug
@@ -3,86 +3,40 @@
   .card
     .card_header
       h2.card_header_text
-        | %{ case maybeStoreEntity }
-        | %{ of Just storeEntity }
-        | \#{fromMaybe "(no title)" (storeName (entityVal storeEntity))}
-        | %{ of Nothing }
-        | (no title)
-        | %{ endcase }
+        | \#{format StoreName coupon}
       .card_header_icon
         .icon.icon-fav.checkableIcon
-          input#js-fav-3.checkableIcon-check.js-fav(type="checkbox" data-coupon-id="\#{fromSqlKey couponKey}")
-          label.checkableIcon-icon(for="js-fav-3")
+          input#js-fav.checkableIcon-check.js-fav(type="checkbox" data-coupon-id="\#{format CouponId coupon}")
+          label.checkableIcon-icon(for="js-fav")
 
     .annotatedImageGroup
       img.annotatedImageGroup-image(
-        src="\#{fromMaybe mempty maybeImageUrl}"
-        alt="七輪焼き肉・安安"
+        src="\#{format ImageUrl coupon}"
+        alt="\#{format StoreName coupon}"
       )
       span.annotatedImageGroup-annotation 画像は一例です
     .card_body
       .card_body_title
-        | \#{couponTitle coupon}
+        | \#{format Title coupon}
 
       .card_body_summary.highlightedBlock
-        | %{ case couponCouponType coupon }
+        | %{ case format CouponType coupon }
         | %{ of CouponTypeDiscount }
-        |     %{ case couponDiscountPercent coupon }
-        |     %{ of Just discountPercent }
-        span.highlightedBlock-sub \#{discountPercent}% OFF
-        |     %{ of Nothing }
-        |     %{ endcase }
-
-        |     %{ case couponDiscountMinimumPrice coupon }
-        |     %{ of Just discountMinimumPrice }
-        span.highlightedBlock-main \#{discountMinimumPrice}円
-        |     %{ of Nothing }
-        |     %{ endcase }
+        span.highlightedBlock-sub \#{format DiscountPercent coupon}
+        span.highlightedBlock-main \#{format DiscountMinimumPrice coupon}
 
         | %{ of CouponTypeGift }
-        |     %{ case couponGiftContent coupon }
-        |     %{ of Just giftContent }
-        span.highlightedBlock-sub \#{giftContent}
-        |     %{ of Nothing }
-        |     %{ endcase }
-
-        |     %{ case couponGiftMinimumPrice coupon }
-        |     %{ of Just giftMinimumPrice }
-        span.highlightedBlock-main \#{giftMinimumPrice}円
-        |     %{ of Nothing }
-        |     %{ endcase }
-
-        |     %{ case couponGiftReferencePrice coupon }
-        |     %{ of Just giftReferencePrice }
-        span.highlightedBlock-main \#{giftReferencePrice}円
-        |     %{ of Nothing }
-        |     %{ endcase }
+        span.highlightedBlock-sub \#{format GiftContent coupon}
+        span.highlightedBlock-main \#{format GiftMinimumPrice coupon}
+        span.highlightedBlock-main \#{format GiftReferencePrice coupon}
 
         | %{ of CouponTypeSet }
-        |     %{ case couponSetContent coupon }
-        |     %{ of Just setContent }
-        span.highlightedBlock-sub \#{setContent}
-        |     %{ of Nothing }
-        |     %{ endcase }
-
-        |     %{ case couponSetPrice coupon }
-        |     %{ of Just setPrice }
-        span.highlightedBlock-main \#{setPrice}円
-        |     %{ of Nothing }
-        |     %{ endcase }
-
-        |     %{ case couponSetReferencePrice coupon }
-        |     %{ of Just setReferencePrice }
-        span.highlightedBlock-main \#{setReferencePrice}円
-        |     %{ of Nothing }
-        |     %{ endcase }
+        span.highlightedBlock-sub \#{format SetContent coupon}
+        span.highlightedBlock-main \#{format SetPrice coupon}
+        span.highlightedBlock-main \#{format SetReferencePrice coupon}
 
         | %{ of CouponTypeOther }
-        |     %{ case couponOtherContent coupon }
-        |     %{ of Just otherContent }
-        span.highlightedBlock-sub \#{otherContent}
-        |     %{ of Nothing }
-        |     %{ endcase }
+        span.highlightedBlock-sub \#{format OtherContent coupon}
 
         | %{ endcase }
 
@@ -91,73 +45,39 @@
         span.card_body_expiration-title
           | 有効期限
         span.card_body_expiration-body
-          | %{ case couponValidFrom coupon }
-          | %{ of Just validFrom }
-          | \#{tshow validFrom}から
-          | %{ of Nothing }
-          | %{ endcase }
-
-          | %{ case couponValidUntil coupon }
-          | %{ of Just validUntil }
-          | \#{tshow validUntil}まで
-          | %{ of Nothing }
-          | %{ endcase }
+          | \#{format ValidFrom coupon}
+          | \#{format ValidUntil coupon}
   .annotation ※ この画面を店舗でご提示ください
   .location
     .location_map
-      | %{ case (join . fmap (storeAddress . entityVal)) maybeStoreEntity }
-      | %{ of Just address }
-      iframe.location_map-frame(
+      .location_map-frame(
         frameborder="0"
         allowfullscreen
-        src='https://www.google.com/maps/embed/v1/place?key=' + data.googleMapApiKey + '&q=\#{address}'
+        data-api-key=data.googleMapApiKey
+        data-address!="\#{format StoreAddress coupon}"
       )
-      | %{ of Nothing }
-      | No address is set
-      | %{ endcase }
   .aboutStore
     a.btn.outerBtn(href="\#{renderRoute storeR}")
-      | %{ case maybeStoreEntity }
-      | %{ of Just storeEntity }
-      | \#{fromMaybe "(no title)" (storeName (entityVal storeEntity))}
-      | %{ of Nothing }
-      | (no title)
-      | %{ endcase }
+      | \#{format StoreName coupon}
   .moreContents
-    | %{ case couponCouponType coupon }
+    | %{ case format CouponType coupon }
     | %{ of CouponTypeDiscount }
-    |     %{ case couponDiscountOtherConditions coupon }
-    |     %{ of Just discountOtherConditions }
-    |         %{ forall condition <- lines discountOtherConditions }
+    |     %{ forall condition <- format DiscountOtherConditions coupon }
     p.moreContents_txt \#{condition}
-    |         %{ endforall }
-    |     %{ of Nothing }
-    |     %{ endcase }
+    |     %{ endforall }
 
     | %{ of CouponTypeGift }
-    |     %{ case couponGiftOtherConditions coupon }
-    |     %{ of Just giftOtherConditions }
-    |         %{ forall condition <- lines giftOtherConditions }
+    |     %{ forall condition <- format GiftOtherConditions coupon }
     p.moreContents_txt \#{condition}
-    |         %{ endforall }
-    |     %{ of Nothing }
-    |     %{ endcase }
+    |     %{ endforall }
 
     | %{ of CouponTypeSet }
-    |     %{ case couponSetOtherConditions coupon }
-    |     %{ of Just setOtherConditions }
-    |         %{ forall condition <- lines setOtherConditions }
+    |     %{ forall condition <- format SetOtherConditions coupon }
     p.moreContents_txt \#{condition}
-    |         %{ endforall }
-    |     %{ of Nothing }
-    |     %{ endcase }
+    |     %{ endforall }
 
     | %{ of CouponTypeOther }
-    |     %{ case couponOtherConditions coupon }
-    |     %{ of Just otherConditions }
-    |         %{ forall condition <- lines otherConditions }
+    |     %{ forall condition <- format OtherConditions coupon }
     p.moreContents_txt \#{condition}
-    |         %{ endforall }
-    |     %{ of Nothing }
-    |     %{ endcase }
+    |     %{ endforall }
     | %{ endcase }

--- a/frontend/src/pug/endUser_coupon_id.pug
+++ b/frontend/src/pug/endUser_coupon_id.pug
@@ -2,4 +2,9 @@ include _layout
   body#main.wrapper
     include _header
       | クーポン
+    | %{ case mdata }
+    | %{ of Just coupon }
     include _coupon_id
+    | %{ of Nothing }
+    | No coupon info.
+    | %{ endcase }

--- a/frontend/src/pug/storeUser_store_coupon_id.pug
+++ b/frontend/src/pug/storeUser_store_coupon_id.pug
@@ -2,8 +2,8 @@ include _layout
   body#main.wrapper
     include _storeHeader
       | クーポン情報
-    | %{ case maybeCouponEntity }
-    | %{ of Just (Entity couponKey coupon) }
+    | %{ case mdata }
+    | %{ of Just coupon }
     .store
       .store_editBtn
         a.btn.outerBtn(href="\#{renderRoute storeCouponVarEditR couponKey}")

--- a/frontend/src/storeUser.js
+++ b/frontend/src/storeUser.js
@@ -2,3 +2,5 @@
 
 // Pull in desired CSS/SASS files
 require('./styles/storeUser.scss');
+
+require('./js/_googleMap.js');

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -74,6 +74,9 @@ library
                      , Kucipong.Spock
                      , Kucipong.Spock.ReqParam
                      , Kucipong.Util
+                     , Kucipong.View
+                     , Kucipong.View.Class
+                     , Kucipong.View.Instance
   build-depends:       base >= 4.7 && < 5
                      , aeson
                      , amazonka

--- a/src/Kucipong/Handler/Consumer.hs
+++ b/src/Kucipong/Handler/Consumer.hs
@@ -8,18 +8,22 @@ import Kucipong.Prelude
 
 import Control.FromSum (fromMaybeM)
 import Data.Default (def)
-import Database.Persist.Sql (Entity(..), fromSqlKey)
+import Database.Persist.Sql (Entity(..))
 import Web.Spock (ActionCtxT, renderRoute)
 import Web.Spock.Core (SpockCtxT, get)
 
-import Kucipong.Db (Coupon(..), CouponType(..), Key(..), Store(..))
+import Kucipong.Db (Coupon(..), CouponType(..), Key(..))
 import Kucipong.Handler.Consumer.Types (ConsumerError(..))
 import Kucipong.Handler.Route (consumerCouponVarR, storeR)
+import Kucipong.Handler.Store.Types
+       (CouponView(..), CouponViewKey(..), CouponViewTypes(..),
+        CouponViewConditions(..), CouponViewCouponType(..))
 import Kucipong.I18n (label)
 import Kucipong.Monad
        (MonadKucipongAws(..), MonadKucipongDb(..), awsImageS3Url,
         dbFindStoreByStoreKey, dbFindPublicCouponById)
 import Kucipong.RenderTemplate (renderTemplateFromEnv)
+import Kucipong.View (View(..))
 
 couponGet
   :: forall ctx m.
@@ -32,6 +36,11 @@ couponGet couponKey = do
   maybeStoreEntity <- dbFindStoreByStoreKey $ couponStoreId coupon
   let maybeImage = couponImage . entityVal =<< maybeCouponEntity
   maybeImageUrl <- traverse awsImageS3Url maybeImage
+  let
+    mdata = CouponView
+      <$> maybeStoreEntity
+      <*> maybeCouponEntity
+      <*> pure maybeImageUrl
   -- TODO
   -- let storeR = undefined
   $(renderTemplateFromEnv "endUser_coupon_id.html")

--- a/src/Kucipong/Handler/Consumer.hs
+++ b/src/Kucipong/Handler/Consumer.hs
@@ -14,7 +14,7 @@ import Web.Spock.Core (SpockCtxT, get)
 
 import Kucipong.Db (Coupon(..), CouponType(..), Key(..))
 import Kucipong.Handler.Consumer.Types (ConsumerError(..))
-import Kucipong.Handler.Route (consumerCouponVarR, storeR)
+import Kucipong.Handler.Route (consumerCouponVarR, consumerStoreVarR)
 import Kucipong.Handler.Store.Types
        (CouponView(..), CouponViewKey(..), CouponViewTypes(..),
         CouponViewConditions(..), CouponViewCouponType(..))
@@ -41,8 +41,10 @@ couponGet couponKey = do
       <$> maybeStoreEntity
       <*> maybeCouponEntity
       <*> pure maybeImageUrl
-  -- TODO
-  -- let storeR = undefined
+    aboutStore =
+      maybe mempty
+        (renderRoute consumerStoreVarR . entityKey)
+        maybeStoreEntity
   $(renderTemplateFromEnv "endUser_coupon_id.html")
   where
     handleErr :: Text -> ActionCtxT ctx m a

--- a/src/Kucipong/Handler/Route.hs
+++ b/src/Kucipong/Handler/Route.hs
@@ -5,7 +5,7 @@ import Web.Routing.Combinators (PathState(Open))
 import Web.Spock (Path, (<//>), var)
 
 import Kucipong.LoginToken (LoginToken)
-import Kucipong.Db (Coupon, Key(..))
+import Kucipong.Db (Coupon, Key(..), Store)
 
 -----------------
 -- Path Pieces --
@@ -89,3 +89,6 @@ storeLoginVarR = storeR <//> loginR <//> var
 
 consumerCouponVarR :: Path '[Key Coupon] 'Open
 consumerCouponVarR = consumerR <//> couponR <//> var
+
+consumerStoreVarR :: Path '[Key Store] 'Open
+consumerStoreVarR = consumerR <//> storeR <//> var

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -90,6 +90,7 @@ couponGet couponKey = do
       <$> maybeStoreEntity
       <*> maybeCouponEntity
       <*> pure maybeImageUrl
+    aboutStore = renderRoute storeR
   $(renderTemplateFromEnv "storeUser_store_coupon_id.html")
 
 couponEditGet

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -1,10 +1,20 @@
 module Kucipong.Handler.Store.Types
   ( StoreError(..)
   , StoreMsg(..)
+  , CouponView(..)
+  , CouponViewKey(..)
+  , CouponViewTypes(..)
+  , CouponViewConditions(..)
+  , CouponViewCouponType(..)
   ) where
 
 import Kucipong.Prelude
 
+import Database.Persist (Entity(..))
+
+import Kucipong.Db (Coupon(..), Store(..))
+
+-- For I18n.
 data StoreError
   = StoreErrorBusinessCategoryDetailIncorrect
   | StoreErrorCouldNotSendEmail
@@ -14,7 +24,43 @@ data StoreError
   | StoreErrorNotAnImage
   deriving (Show, Eq, Ord, Read)
 
-data StoreMsg
-  = StoreMsgSentVerificationEmail
+data StoreMsg =
+  StoreMsgSentVerificationEmail
   deriving (Show, Eq, Ord, Read, Enum, Bounded)
 
+-- For View.
+data CouponView = CouponView
+  { couponStore :: Entity Store
+  , couponCoupon :: Entity Coupon
+  , couponImageUrl :: Maybe Text
+  } deriving (Show, Eq)
+
+data CouponViewKey
+  = StoreId
+  | CouponId
+
+data CouponViewTypes
+  = StoreName
+  | StoreAddress
+  | ImageUrl
+  | Title
+  | ValidFrom
+  | ValidUntil
+  | DiscountPercent
+  | DiscountMinimumPrice
+  | GiftContent
+  | GiftMinimumPrice
+  | GiftReferencePrice
+  | SetContent
+  | SetPrice
+  | SetReferencePrice
+  | OtherContent
+
+data CouponViewConditions
+  = DiscountOtherConditions
+  | GiftOtherConditions
+  | SetOtherConditions
+  | OtherConditions
+
+data CouponViewCouponType =
+  CouponType

--- a/src/Kucipong/View.hs
+++ b/src/Kucipong/View.hs
@@ -1,0 +1,4 @@
+module Kucipong.View ( module X ) where
+
+import Kucipong.View.Class as X
+import Kucipong.View.Instance as X ()

--- a/src/Kucipong/View/Class.hs
+++ b/src/Kucipong/View/Class.hs
@@ -1,0 +1,6 @@
+module Kucipong.View.Class where
+
+-- | Way to format data on front-end side.
+class View o t where
+  type ViewO t
+  format :: t -> o -> ViewO t

--- a/src/Kucipong/View/Instance.hs
+++ b/src/Kucipong/View/Instance.hs
@@ -1,0 +1,77 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Kucipong.View.Instance where
+
+import Kucipong.Prelude
+
+import Database.Persist (Entity(..))
+import Database.Persist.Sql (fromSqlKey)
+
+import Kucipong.Db
+       (Coupon(..), CouponType(..), Percent, Price, Store(..),
+        percentToText, priceToText)
+import Kucipong.Handler.Store.Types
+       (CouponView(..), CouponViewKey(..), CouponViewTypes(..),
+        CouponViewConditions(..), CouponViewCouponType(..))
+import Kucipong.View.Class (View(..))
+
+instance View CouponView CouponViewKey where
+  type ViewO CouponViewKey = Int64
+  format StoreId = fromSqlKey . entityKey . couponStore
+  format CouponId = fromSqlKey . entityKey . couponCoupon
+
+instance View CouponView CouponViewTypes where
+  type ViewO CouponViewTypes = Text
+  format StoreName = fromMaybe "(no title)" . storeName . store
+  format StoreAddress = fromMaybe mempty . storeAddress . store
+  format ImageUrl = fromMaybe mempty . couponImageUrl
+  format Title = couponTitle . coupon
+  format ValidFrom = maybe mempty formatValidFrom . couponValidFrom . coupon
+  format ValidUntil = maybe mempty formatValidUntil . couponValidFrom . coupon
+  format DiscountPercent =
+    maybe mempty formatDiscountPercent . couponDiscountPercent . coupon
+  format DiscountMinimumPrice =
+    maybe mempty formatCurrency . couponDiscountMinimumPrice . coupon
+  format GiftContent = maybe mempty tshow . couponGiftContent . coupon
+  format GiftMinimumPrice =
+    maybe mempty formatCurrency . couponGiftMinimumPrice . coupon
+  format GiftReferencePrice =
+    maybe mempty formatCurrency . couponGiftReferencePrice . coupon
+  format SetContent = maybe mempty tshow . couponSetContent . coupon
+  format SetPrice = maybe mempty formatCurrency . couponSetPrice . coupon
+  format SetReferencePrice =
+    maybe mempty formatCurrency . couponSetReferencePrice . coupon
+  format OtherContent = maybe mempty tshow . couponOtherContent . coupon
+
+instance View CouponView CouponViewConditions where
+  type ViewO CouponViewConditions = [Text]
+  format DiscountOtherConditions =
+    concatMap lines . couponDiscountOtherConditions . coupon
+  format GiftOtherConditions =
+    concatMap lines . couponGiftOtherConditions . coupon
+  format SetOtherConditions =
+    concatMap lines . couponSetOtherConditions . coupon
+  format OtherConditions = concatMap lines . couponOtherConditions . coupon
+
+instance View CouponView CouponViewCouponType where
+  type ViewO CouponViewCouponType = CouponType
+  format CouponType = couponCouponType . coupon
+
+store :: CouponView -> Store
+store = entityVal . couponStore
+
+coupon :: CouponView -> Coupon
+coupon = entityVal . couponCoupon
+
+-- Helper functions
+formatValidFrom :: Day -> Text
+formatValidFrom day = "From " <> tshow day
+
+formatValidUntil :: Day -> Text
+formatValidUntil day = "To " <> tshow day
+
+formatCurrency :: Price -> Text
+formatCurrency p = "$" <> priceToText p
+
+formatDiscountPercent :: Percent -> Text
+formatDiscountPercent p = percentToText p <> "%"

--- a/src/Kucipong/View/Instance.hs
+++ b/src/Kucipong/View/Instance.hs
@@ -22,7 +22,7 @@ instance View CouponView CouponViewKey where
 
 instance View CouponView CouponViewTypes where
   type ViewO CouponViewTypes = Text
-  format StoreName = fromMaybe "(no title)" . storeName . store
+  format StoreName = fromMaybe "(no store name)" . storeName . store
   format StoreAddress = fromMaybe mempty . storeAddress . store
   format ImageUrl = fromMaybe mempty . couponImageUrl
   format Title = couponTitle . coupon


### PR DESCRIPTION
This PR is part of #143.
This slims down `frontend/src/pub/_coupon_id.pug` file and its dependent files.

* In commit 88158be, I introduced `Kucipong/View/*` to keep maintainability and simplicity of template files.
* af7d8bb actually rewrites template files with `View` type class.

I'll rewrite other template files in future PR.