### PR TITLE
Allow Admin user to login as a Store

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -6,6 +6,7 @@ build: yarn-install
 
 clean:
 	rm -rf dist
+	rm -rf elm-stuff
 
 yarn-install:
 	yarn install

--- a/frontend/src/pug/adminUser_admin_store_login.pug
+++ b/frontend/src/pug/adminUser_admin_store_login.pug
@@ -2,6 +2,7 @@ include _layout
   body#main.wrapper
     include _adminHeader
       | 店舗ユーザとしてログイン
+    include _messageArea
     .admin
       .adminBody
         .signboard_titleArea

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -60,6 +60,12 @@ data AdminStoreDeleteForm = AdminStoreDeleteForm
 
 instance FromForm AdminStoreDeleteForm
 
+data AdminStoreLoginForm = AdminStoreLoginForm
+  { storeEmail :: !EmailAddress
+  } deriving (Data, Eq, Generic, Read, Show, Typeable)
+
+instance FromForm AdminStoreLoginForm
+
 -----------
 -- Store --
 -----------

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -26,11 +26,13 @@ import Kucipong.Form
        (AdminLoginForm(AdminLoginForm),
         AdminStoreCreateForm(AdminStoreCreateForm),
         AdminStoreDeleteForm(AdminStoreDeleteForm),
-        AdminStoreDeleteConfirmForm(AdminStoreDeleteConfirmForm))
+        AdminStoreDeleteConfirmForm(AdminStoreDeleteConfirmForm),
+        AdminStoreLoginForm(AdminStoreLoginForm))
 import Kucipong.Handler.Admin.Types (AdminError(..), AdminMsg(..))
 import Kucipong.Handler.Route
        (adminR, adminLoginR, adminLoginVarR, adminStoreCreateR,
-        adminStoreDeleteR, adminStoreDeleteConfirmR, adminStoreLoginR)
+        adminStoreDeleteR, adminStoreDeleteConfirmR, adminStoreLoginR,
+        storeR)
 import Kucipong.I18n (label)
 import Kucipong.LoginToken (LoginToken)
 import Kucipong.Monad
@@ -42,7 +44,7 @@ import Kucipong.RenderTemplate (renderTemplateFromEnv)
 import Kucipong.Session (Admin, Session(..))
 import Kucipong.Spock
        (ContainsAdminSession, getAdminCookie, getAdminEmail,
-        getReqParamErr, setAdminCookie)
+        getReqParamErr, setAdminCookie, setStoreCookie)
 
 -- | Handler for returning the admin login page.
 loginGet
@@ -105,6 +107,30 @@ doLoginGet loginToken = do
       setStatus forbidden403
       let errors = [label def AdminErrorTokenExpired]
       $(renderTemplateFromEnv "adminUser_login.html")
+
+loginAsStorePost
+  :: forall xs m.
+     ( MonadIO m
+     , MonadKucipongCookie m
+     , MonadKucipongDb m
+     , MonadLogger m
+     )
+  => ActionCtxT (HVect xs) m ()
+loginAsStorePost = do
+  (AdminStoreLoginForm storeEmailParam) <- getReqParamErr handleErr
+  maybeStoreEntity <- dbFindStoreByEmail storeEmailParam
+  (Entity storeKey _) <-
+    fromMaybeM (handleErr $ label def AdminErrorNoStoreEmail) maybeStoreEntity
+  setStoreCookie storeKey
+  redirect $ renderRoute storeR
+  where
+    handleErr :: Text -> ActionCtxT (HVect xs) m a
+    handleErr errMsg = do
+      $(logDebug) $
+        "got following error in admin loginAsStorePost handler: " <> errMsg
+      let errors = [errMsg]
+      undefined
+      -- $(renderTemplateFromEnv "adminUser_admin_store_delete.html")
 
 -- | Return the store create page for an admin.
 storeCreateGet
@@ -233,3 +259,5 @@ adminComponent = do
     get adminStoreDeleteR storeDeleteGet
     post adminStoreDeleteR storeDeletePost
     post adminStoreDeleteConfirmR storeDeleteConfirmPost
+    -- get adminStoreLoginR loginAsStoreGet
+    post adminStoreLoginR loginAsStorePost

--- a/src/Kucipong/Handler/Admin.hs
+++ b/src/Kucipong/Handler/Admin.hs
@@ -108,6 +108,13 @@ doLoginGet loginToken = do
       let errors = [label def AdminErrorTokenExpired]
       $(renderTemplateFromEnv "adminUser_login.html")
 
+-- | Return the store create page for an admin.
+loginAsStoreGet
+  :: forall xs m.
+     MonadIO m
+  => ActionCtxT (HVect xs) m ()
+loginAsStoreGet = $(renderTemplateFromEnv "adminUser_admin_store_login.html")
+
 loginAsStorePost
   :: forall xs m.
      ( MonadIO m
@@ -129,8 +136,7 @@ loginAsStorePost = do
       $(logDebug) $
         "got following error in admin loginAsStorePost handler: " <> errMsg
       let errors = [errMsg]
-      undefined
-      -- $(renderTemplateFromEnv "adminUser_admin_store_delete.html")
+      $(renderTemplateFromEnv "adminUser_admin_store_login.html")
 
 -- | Return the store create page for an admin.
 storeCreateGet
@@ -259,5 +265,5 @@ adminComponent = do
     get adminStoreDeleteR storeDeleteGet
     post adminStoreDeleteR storeDeletePost
     post adminStoreDeleteConfirmR storeDeleteConfirmPost
-    -- get adminStoreLoginR loginAsStoreGet
+    get adminStoreLoginR loginAsStoreGet
     post adminStoreLoginR loginAsStorePost


### PR DESCRIPTION
This PR adds functionality to allow the `Admin` user to login as a `Store`.

http://localhost:8101/admin/store/login

Closes #148.