### PR TITLE
Allow the store user to delete coupons.

### DIFF
--- a/frontend/src/pug/404.pug
+++ b/frontend/src/pug/404.pug
@@ -1,0 +1,5 @@
+include common/_layout
+  body#main.wrapper
+    include common/_messageArea
+
+    | 404! Not found!

--- a/frontend/src/pug/common/_coupon_id.pug
+++ b/frontend/src/pug/common/_coupon_id.pug
@@ -81,3 +81,13 @@
     p.moreContents_txt \#{condition}
     |     %{ endforall }
     | %{ endcase }
+
+  | %{ case pageViewer }
+  | %{ of PageViewerStore }
+  .deleteCoupon
+    a.btn.outerBtn(
+      href="\#{renderRoute storeCouponDeleteVarR (entityKey (couponCoupon coupon))}"
+    )
+      | クーポンの削除
+  | %{ of _ }
+  | %{ endcase}

--- a/frontend/src/pug/store/coupon_delete.pug
+++ b/frontend/src/pug/store/coupon_delete.pug
@@ -1,0 +1,25 @@
+include ../common/_layout
+  body#main.wrapper
+    include _header
+      | クーポン削除
+    include ../common/_messageArea
+    .admin
+      .adminBody
+        .signboard_titleArea
+          .signboard_titleArea-title
+            | クーポンの削除
+        form.signboard_body(
+          method="POST"
+          action="\#{renderRoute storeCouponDeleteVarR couponKey}"
+        )
+          input#couponId(
+            type="hidden" value="\#{fromSqlKey couponKey}"
+          )
+          .row
+            | 「\#{couponTitle}」を削除しますか？
+          .submitRow
+            button.btn.outerBtn(type="submit")
+              | このクーポンを削除
+            a.btn.outerBtn(href="\#{renderRoute storeCouponVarR couponKey}")
+              | 戻る
+

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -91,6 +91,7 @@ const commonConfig = {
     ].concat(
       [
         // Pages for end users.
+        '404',
         'category',
         'coupon_id',
         'store_id',
@@ -106,6 +107,7 @@ const commonConfig = {
         'store',
         'store_edit',
         'coupon',
+        'coupon_delete',
         'coupon_id',
         'coupon_id_edit',
       ].map((template) => ({

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -36,6 +36,8 @@ library
                      , Kucipong.Handler.Consumer
                      , Kucipong.Handler.Consumer.TemplatePath
                      , Kucipong.Handler.Consumer.Types
+                     , Kucipong.Handler.Error
+                     , Kucipong.Handler.Error.TemplatePath
                      , Kucipong.Handler.Route
                      , Kucipong.Handler.Store
                      , Kucipong.Handler.Store.Coupon
@@ -44,6 +46,7 @@ library
                      , Kucipong.Handler.Store.Util
                      , Kucipong.Handler.Static
                      , Kucipong.Handler.Static.TH
+                     , Kucipong.Handler.Types
                      , Kucipong.Host
                      , Kucipong.I18n
                      , Kucipong.I18n.Class

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -17,8 +17,8 @@ import Web.FormUrlEncoded (FromForm)
 import Web.HttpApiData (FromHttpApiData(..))
 
 import Kucipong.Db
-       (BusinessCategory(..), BusinessCategoryDetail(..), CouponType(..),
-        Image(..), Percent(..), Price(..))
+       (BusinessCategory(..), BusinessCategoryDetail(..),
+        CouponType(..), Image(..), Percent(..), Price(..))
 
 newtype MaybeEmpty a = MaybeEmpty
   { unMaybeEmpty :: Maybe a

--- a/src/Kucipong/Handler/Consumer.hs
+++ b/src/Kucipong/Handler/Consumer.hs
@@ -15,10 +15,12 @@ import Web.Spock.Core (SpockCtxT, get)
 import Kucipong.Db (Coupon(..), CouponType(..), Key(..))
 import Kucipong.Handler.Consumer.TemplatePath
 import Kucipong.Handler.Consumer.Types (ConsumerError(..))
-import Kucipong.Handler.Route (consumerCouponVarR, consumerStoreVarR)
+import Kucipong.Handler.Route
+       (consumerCouponVarR, consumerStoreVarR, storeCouponDeleteVarR)
 import Kucipong.Handler.Store.Types
        (CouponView(..), CouponViewKey(..), CouponViewTypes(..),
         CouponViewConditions(..), CouponViewCouponType(..))
+import Kucipong.Handler.Types (PageViewer(..))
 import Kucipong.I18n (label)
 import Kucipong.Monad
        (MonadKucipongAws(..), MonadKucipongDb(..), awsImageS3Url,
@@ -46,6 +48,7 @@ couponGet couponKey = do
       maybe mempty
         (renderRoute consumerStoreVarR . entityKey)
         maybeStoreEntity
+    pageViewer = PageViewerEndUser
   $(renderTemplateFromEnv templateCouponId)
   where
     handleErr :: Text -> ActionCtxT ctx m a

--- a/src/Kucipong/Handler/Error.hs
+++ b/src/Kucipong/Handler/Error.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Kucipong.Handler.Error
+  ( resp404
+  ) where
+
+import Kucipong.Prelude
+
+import Network.HTTP.Types (status404)
+import Web.Spock (ActionCtxT, setStatus)
+
+import Kucipong.RenderTemplate (renderTemplateFromEnv)
+import Kucipong.Handler.Error.TemplatePath (template404)
+
+resp404 :: MonadIO m => [Text] -> ActionCtxT ctx m ()
+resp404 errors = do
+  setStatus status404
+  $(renderTemplateFromEnv template404)

--- a/src/Kucipong/Handler/Error/TemplatePath.hs
+++ b/src/Kucipong/Handler/Error/TemplatePath.hs
@@ -1,0 +1,14 @@
+module Kucipong.Handler.Error.TemplatePath where
+
+import Kucipong.Prelude
+
+-- =====================
+--  Template file paths
+-- =====================
+
+-- | File path to template file directory for admin pages.
+templateRoot :: FilePath
+templateRoot = ""
+
+template404 :: FilePath
+template404 = templateRoot </> "404.html"

--- a/src/Kucipong/Handler/Route.hs
+++ b/src/Kucipong/Handler/Route.hs
@@ -72,6 +72,12 @@ storeCouponR = storeR <//> couponR
 storeCouponCreateR :: Path '[] 'Open
 storeCouponCreateR = storeR <//> couponR <//> createR
 
+storeCouponDeleteR :: Path '[] 'Open
+storeCouponDeleteR = storeR <//> couponR <//> deleteR
+
+storeCouponDeleteVarR :: Path '[Key Coupon] 'Open
+storeCouponDeleteVarR = storeR <//> couponR <//> deleteR <//> var
+
 storeCouponVarR :: Path '[Key Coupon] 'Open
 storeCouponVarR = storeR <//> couponR <//> var
 

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -372,7 +372,7 @@ couponPost = do
           , "defaultImage"
           ])
 
--- | Return the store create page for an admin.
+-- | Return the coupon delete page for a store.
 couponDeleteGet
   :: forall xs n m.
      (ContainsStoreSession n xs, MonadIO m, MonadKucipongDb m)

--- a/src/Kucipong/Handler/Store/TemplatePath.hs
+++ b/src/Kucipong/Handler/Store/TemplatePath.hs
@@ -22,6 +22,9 @@ templateStoreEdit = templateRoot </> "store_edit.html"
 templateCoupon :: FilePath
 templateCoupon = templateRoot </> "coupon.html"
 
+templateCouponDelete :: FilePath
+templateCouponDelete = templateRoot </> "coupon_delete.html"
+
 templateCouponId :: FilePath
 templateCouponId = templateRoot </> "coupon_id.html"
 

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -19,6 +19,7 @@ data StoreError
   = StoreErrorBusinessCategoryDetailIncorrect
   | StoreErrorCouldNotSendEmail
   | StoreErrorCouldNotUploadImage
+  | StoreErrorCouponNotFound
   | StoreErrorNoImage
   | StoreErrorNoStoreEmail EmailAddress
   | StoreErrorNotAnImage

--- a/src/Kucipong/Handler/Types.hs
+++ b/src/Kucipong/Handler/Types.hs
@@ -1,0 +1,13 @@
+module Kucipong.Handler.Types
+  ( PageViewer(..)
+  ) where
+
+import Kucipong.Prelude
+
+-- | The user who is viewing a given webpage.
+data PageViewer
+  = PageViewerAdmin
+  | PageViewerEndUser
+  | PageViewerStore
+  deriving (Bounded, Data, Enum, Eq, Read, Show, Typeable)
+

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -16,7 +16,8 @@ import Kucipong.Db.Models.Base
 import Kucipong.Handler.Admin.Types (AdminError(..), AdminMsg(..))
 import Kucipong.Handler.Consumer.Types (ConsumerError(..))
 import Kucipong.Handler.Store.Types (StoreError(..), StoreMsg(..))
-import Kucipong.Monad.Db.Class (StoreDeleteResult(..))
+import Kucipong.Monad.Db.Class
+       (CouponDeleteResult(..), StoreDeleteResult(..))
 
 import Text.EmailAddress (toText)
 
@@ -57,6 +58,10 @@ instance I18n StoreDeleteResult where
   label EnUS (StoreDeleteErrDoesNotExist email) =
     "Store with email address of \"" <> toText email <> "\" does not exist."
 
+instance I18n CouponDeleteResult where
+  label EnUS CouponDeleteSuccess = "Successfully deleted coupon."
+  label EnUS CouponDeleteErrDoesNotExist = "Coupon with that ID does not exist."
+
 instance I18n StoreError where
   label EnUS StoreErrorBusinessCategoryDetailIncorrect =
     "Business category details do not belong to the selected business category."
@@ -64,6 +69,8 @@ instance I18n StoreError where
     "Could not send email. Please try again."
   label EnUS StoreErrorCouldNotUploadImage =
     "Could not upload image. Please try again."
+  label EnUS StoreErrorCouponNotFound =
+    "Could not find the specified coupon."
   label EnUS StoreErrorNoImage =
     "Failed to upload image. Please try again."
   label EnUS (StoreErrorNoStoreEmail email) =


### PR DESCRIPTION
This PR allows the `Store` user to delete `Coupon`s.

If you go to a store user coupon page, there is a new delete button at the bottom.

http://localhost:8101/store/coupon/13

Clicking that takes you to the coupon delete page:

http://localhost:8101/store/coupon/delete/13

@arowM There are three things I'd appreciate if you'd take a look at.

1.  I added a 404 page.
    
    https://github.com/blueimpact/kucipong/pull/155/files#diff-31376d72c1f6a4671661d54e0773c618
    https://github.com/blueimpact/kucipong/pull/155/files#diff-66a030d00a32f20aa50ae4fbae9ed27eR384
    
    I think this will simplify some of the handlers for truely exceptional conditions.  For instance, the `Store` user will probably never go to the coupon delete page for a coupon that has already been deleted.  I think it makes sense to just return a 404 page here.

    There are also a couple other handlers in the app that could probably just return a 404 page (instead of showing the user an error message).

2.  The coupon delete page looks a little funny.  If you have any good ideas for making it look better, I'd appreciate it.
    
    https://github.com/blueimpact/kucipong/pull/155/files#diff-14cfbdf62dc35a70414bf93a359c8f98

3.  Since the coupon id template (`frontend/src/pug/common/_coupon_id.pug`) is the same for the end user and store user, I had to add an ugly hack to determine whether or not to show the coupon delete button.  Can you think of any better way of doing this?
    
    https://github.com/blueimpact/kucipong/pull/155/files#diff-38506ea977d44a1bbae213029893f447R85
    https://github.com/blueimpact/kucipong/pull/155/files#diff-d9ff201ce1e331481f5cf6639f82d4dfR8
    