### PR TITLE
Create JSON API for deleting coupons.

### DIFF
--- a/src/Kucipong/Monad/Db/Class.hs
+++ b/src/Kucipong/Monad/Db/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Kucipong.Monad.Db.Class where
@@ -6,6 +6,7 @@ module Kucipong.Monad.Db.Class where
 import Kucipong.Prelude
 
 import Control.Monad.Trans (MonadTrans)
+import Data.Aeson.TH (defaultOptions, deriveJSON)
 import Database.Persist.Sql
        (Entity, Filter, PersistRecordBackend, SelectOpt, SqlBackend,
         Update)
@@ -25,6 +26,8 @@ data CouponDeleteResult
   -- ^ There is no 'Coupon' in the database for the 'Key' 'Coupon' and 'Key'
   -- 'Store' that was passed in.
   deriving (Eq, Generic, Show, Typeable)
+
+$(deriveJSON defaultOptions ''CouponDeleteResult)
 
 -- | Result to return from a call to 'dbDeleteStoreIfNameMatches'.
 data StoreDeleteResult


### PR DESCRIPTION
This PR adds a JSON API for deleting coupons for the store user.

This fixes #156.

Here is an example of accessing this API on the command line:

```sh
$ curl --verbose --request POST --header 'Accept: application/json' \
    --cookie 'storeEmail=KoS9pmg2DXfpGEEE6N76ooo6N7JCIuecTgg44aIV8eBd7khH8zlV44unPg9iGu8eLGSkEI0Sw%3D%3D' \
     'http://localhost:8101/store/coupon/delete/15'
```