### PR TITLE
Slimdown store templates

### DIFF
--- a/frontend/src/pug/common/_coupon_id.pug
+++ b/frontend/src/pug/common/_coupon_id.pug
@@ -11,7 +11,7 @@
 
     .annotatedImageGroup
       img.annotatedImageGroup-image(
-        src="\#{format ImageUrl coupon}"
+        src="\#{format CouponImageUrl coupon}"
         alt="\#{format StoreName coupon}"
       )
       span.annotatedImageGroup-annotation 画像は一例です

--- a/frontend/src/pug/store/store.pug
+++ b/frontend/src/pug/store/store.pug
@@ -34,14 +34,14 @@ include ../common/_layout
               .storeBody_info_body_row-header
                 | カテゴリ
               .storeBody_info_body_row-body
-                | \#{ format StoreBusinessCategory store}
+                | \#{ label (format StoreBusinessCategory store)}
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 店舗の特徴
               .storeBody_info_body_row-body.simpleTagWrapper
                 | %{ forall businessCategoryDetail <- format StoreBusinessCategoryDetails store }
                 .simpleTag
-                  | \#{ businessCategoryDetail }
+                  | \#{ label businessCategoryDetail }
                 | %{ endforall }
             .storeBody_info_body_row
               .storeBody_info_body_row-header

--- a/frontend/src/pug/store/store.pug
+++ b/frontend/src/pug/store/store.pug
@@ -4,22 +4,25 @@ include ../common/_layout
     include _header
       | 店舗情報
     include ../common/_messageArea
+    | %{ case mdata }
+    | %{ of Just store }
+
     .store
       .store_editBtn
         a.btn.outerBtn(href="\#{renderRoute storeEditR}") 店舗情報編集
       header.storeHeader
         .annotatedImageGroup
           img.annotatedImageGroup-image(
-            src="\#{fromMaybe mempty imageUrl}"
-            alt!='\#{fromMaybe "(no name)" name}'
+            src="\#{format StoreImageUrl store}"
+            alt!='\#{format StoreName store}'
           )
           span.annotatedImageGroup-annotation 画像は一例です
         .highlightedBlock
           h2.highlightedBlock.storeHeader-title
-            | \#{fromMaybe "(no name)" name}
+            | \#{format StoreName store}
       .storeBody
         .storeBody_description
-          p \#{ fromMaybe mempty salesPoint }
+          p \#{format StoreSalesPoint store}
         .storeBody_couponBtn
           a.btn.defaultBtn(href="\#{renderRoute storeCouponR}") クーポン一覧
         .storeBody_info
@@ -31,48 +34,52 @@ include ../common/_layout
               .storeBody_info_body_row-header
                 | カテゴリ
               .storeBody_info_body_row-body
-                | \#{ label (fromMaybe minBound businessCategory) }
+                | \#{ format StoreBusinessCategory store}
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 店舗の特徴
               .storeBody_info_body_row-body.simpleTagWrapper
-                | %{ forall businessCategoryDetail <- businessCategoryDetails }
+                | %{ forall businessCategoryDetail <- format StoreBusinessCategoryDetails store }
                 .simpleTag
-                  | \#{ label businessCategoryDetail }
+                  | \#{ businessCategoryDetail }
                 | %{ endforall }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 住所
               .storeBody_info_body_row-body
                 .storeBody_info_body_row-body-address
-                  | \#{ fromMaybe mempty address }
+                  | \#{format StoreAddress store}
                 .storeBody_info_body_row-body-map
-                  | %{ case address }
-                  | %{ of Just address }
-                  iframe.location_map-frame(
+                  iframe.location_map-frame.js-googleMap(
                     frameborder="0"
                     allowfullscreen
-                    src='https://www.google.com/maps/embed/v1/place?key=' + data.googleMapApiKey + '&q=\#{address}'
+                    data-api-key=data.googleMapApiKey
+                    data-address!="\#{format StoreAddress store}"
                   )
-                  | %{ of Nothing }
-                  | %{ endcase }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 電話番号
               .storeBody_info_body_row-body
-                | \#{ fromMaybe mempty phoneNumber }
+                | \#{format StorePhoneNumber store}
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 営業時間
               .storeBody_info_body_row-body
-                | %{ forall businessHourLine <- businessHourLines }
+                | %{ forall businessHour <- format StoreBusinessHour store }
                 p
-                  | \#{ businessHourLine }
+                  | \#{businessHour}
                 | %{ endforall }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 定休日
               .storeBody_info_body_row-body
-                | \#{ fromMaybe mempty regularHoliday }
+                | \#{format StoreRegularHoliday store}
             .storeBody_info_body_btnRow
-              a.btn.outerBtn(href="\#{ fromMaybe mempty url }") オフィシャルサイト
+              a.btn.outerBtn(href="\#{format StoreUrl store}") オフィシャルサイト
+
+    | %{ of Nothing }
+    | No store info.
+    | %{ endcase }
+
+
+

--- a/frontend/src/pug/store/store_edit.pug
+++ b/frontend/src/pug/store/store_edit.pug
@@ -5,6 +5,8 @@ include ../common/_layout
       | 店舗情報 編集
     include ../common/_messageArea
     form.store(enctype="multipart/form-data" method="POST")
+      | %{ case mdata }
+      | %{ of Just store }
       .storeBody
         .storeBody_info
           .storeBody_info_titleArea
@@ -17,7 +19,7 @@ include ../common/_layout
               .storeBody_info_body_row-body
                 input#storeName(
                   name="name" type="text"
-                  value="\#{ fromMaybe mempty name }"
+                  value="\#{format StoreName store}"
                 )
             .storeBody_info_body_row
               .storeBody_info_body_row-header
@@ -29,7 +31,11 @@ include ../common/_layout
                 )
                   option(value="" disabled)
                   | %{ forall category <- allBusinessCategories }
-                  option(value="\#{key category}" #{isSelected businessCategory category}) \#{label category}
+                  option(
+                    value="\#{key category}"
+                    \#{isSelected (Just (format StoreBusinessCategory store)) category}
+                  )
+                    | \#{label category}
                   | %{ endforall }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
@@ -42,7 +48,7 @@ include ../common/_layout
                       id="storeTagsCommon-\#{key categoryDetail}"
                       type="checkbox" name="businessCategoryDetails"
                       value="\#{key categoryDetail}"
-                      #{isChecked businessCategoryDetails categoryDetail}
+                      #{isChecked (format StoreBusinessCategoryDetails store) categoryDetail}
                     )
                     label.checkboxLabel(for="storeTagsCommon-\#{key categoryDetail}")
                       | \#{label categoryDetail}
@@ -57,7 +63,7 @@ include ../common/_layout
                       id="storeTags\#{key category}-\#{key categoryDetail}"
                       type="checkbox" name="businessCategoryDetails"
                       value="\#{key categoryDetail}"
-                      #{isChecked businessCategoryDetails categoryDetail}
+                      #{isChecked (format StoreBusinessCategoryDetails store) categoryDetail}
                     )
                     label.checkboxLabel(for="storeTags\#{key category}-\#{key categoryDetail}")
                       | \#{label categoryDetail}
@@ -71,7 +77,7 @@ include ../common/_layout
                   name="salesPoint"
                   type="text"
                 )
-                  | \#{ fromMaybe mempty salesPoint }
+                  | \#{format StoreSalesPoint store}
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 住所
@@ -79,32 +85,22 @@ include ../common/_layout
                 .storeBody_info_body_row-body-address
                   input#storeAddress(
                     name="address" type="text"
-                    value="\#{ fromMaybe mempty address }"
+                    value="\#{format StoreAddress store}"
                   )
                 .storeBody_info_body_row-body-map#js-map-frame-wrapper
-                  | %{ case address }
-                  | %{ of Just address }
-                  iframe#js-map-frame.location_map-frame(
+                  iframe.location_map-frame.js-googleMap(
                     frameborder="0"
                     allowfullscreen
-                    data-map-base-api='https://www.google.com/maps/embed/v1/place?key=' + data.googleMapApiKey + '&q='
-                    src='https://www.google.com/maps/embed/v1/place?key=' + data.googleMapApiKey + '&q=\#{address}'
+                    data-api-key=data.googleMapApiKey
+                    data-address!="\#{format StoreAddress store}"
                   )
-                  | %{ of Nothing }
-                  iframe#js-map-frame.location_map-frame(
-                    frameborder="0"
-                    allowfullscreen
-                    data-map-base-api='https://www.google.com/maps/embed/v1/place?key=' + data.googleMapApiKey + '&q='
-                    aria-hidden="true"
-                  )
-                  | %{ endcase }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 電話番号
               .storeBody_info_body_row-body
                 input#storePhoneNumber(
                   name="phoneNumber" type="text"
-                  value="\#{ fromMaybe mempty phoneNumber }"
+                  value="\#{format StorePhoneNumber store}"
                 )
             .storeBody_info_body_row
               .storeBody_info_body_row-header
@@ -113,8 +109,8 @@ include ../common/_layout
                 textarea#storeBusinessHours(
                   name="businessHours" type="text"
                 )
-                  | %{ forall businessHourLine <- businessHourLines }
-                  | \#{ businessHourLine }
+                  | %{ forall hour <- format StoreBusinessHour store }
+                  | \#{hour}
                   | %{ endforall }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
@@ -123,14 +119,14 @@ include ../common/_layout
                 textarea#storeRegularHoliday(
                   name="regularHoliday" type="text"
                 )
-                  | \#{ fromMaybe mempty regularHoliday }
+                  | \#{format StoreRegularHoliday store}
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | オフィシャルサイト
               .storeBody_info_body_row-body
                 input#storeUrl(
                   name="url" type="url"
-                  value="\#{ fromMaybe mempty url }"
+                  value="\#{format StoreUrl store}"
                 )
             .storeBody_info_body_row
               .storeBody_info_body_row-header
@@ -141,21 +137,17 @@ include ../common/_layout
                     name="image" type="file" accept="image/*"
                   )
                   input#defaultImage.js-imageSelectorDefaultImage(
-                    name="defaultImage" type="hidden" value="\#{fromMaybe mempty defaultImage}"
+                    name="defaultImage" type="hidden" value="\#{format StoreDefaultImage store}"
                   )
-                  | %{ case imageUrl }
-                  | %{ of Just iUrl }
                   label#storeImageLabel.uploaderLabel
                   button.uploaderReset#resetImage(type="button")
                     | Restore initial image.
                   img#storeImage.uploaderImg.storeBody_info_body_row-body-image(
-                    src="\#{iUrl}"
+                    src="\#{format StoreImageUrl store}"
                   )
-                  | %{ of Nothing }
-                  label#storeImageLabel.uploaderLabel.js-imageSelectorUploadBtn(for="storeImageSelector")
-                  img#storeImage.uploaderImg.storeBody_info_body_row-body-image.js-imageSelectorPreview(
-                  )
-                  | %{ endcase }
             .storeSubmit
               button.btn.outerBtn(type="submit")
                 | この内容で店舗情報を更新する
+      | %{ of Nothing }
+      | No store info.
+      | %{ endcase }

--- a/src/Kucipong/Handler/Consumer.hs
+++ b/src/Kucipong/Handler/Consumer.hs
@@ -19,7 +19,8 @@ import Kucipong.Handler.Route
        (consumerCouponVarR, consumerStoreVarR, storeCouponDeleteVarR)
 import Kucipong.Handler.Store.Types
        (CouponView(..), CouponViewKey(..), CouponViewTypes(..),
-        CouponViewConditions(..), CouponViewCouponType(..))
+        CouponViewImageUrl(..), CouponViewConditions(..),
+        CouponViewCouponType(..), StoreViewText(..))
 import Kucipong.Handler.Types (PageViewer(..))
 import Kucipong.I18n (label)
 import Kucipong.Monad

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -29,7 +29,8 @@ import Kucipong.Handler.Store.TemplatePath
 import Kucipong.Handler.Store.Types
        (StoreError(..), CouponView(..), CouponViewKey(..),
         CouponViewTypes(..), CouponViewConditions(..),
-        CouponViewCouponType(..))
+        CouponViewCouponType(..), CouponViewImageUrl(..),
+        StoreViewText(..))
 import Kucipong.Handler.Store.Util
        (UploadImgErr(..), uploadImgToS3WithDef)
 import Kucipong.Handler.Types (PageViewer(..))

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -6,6 +6,11 @@ module Kucipong.Handler.Store.Types
   , CouponViewTypes(..)
   , CouponViewConditions(..)
   , CouponViewCouponType(..)
+  , CouponViewImageUrl(..)
+  , StoreView(..)
+  , StoreViewImageUrl(..)
+  , StoreViewText(..)
+  , StoreViewTexts(..)
   ) where
 
 import Kucipong.Prelude
@@ -40,11 +45,11 @@ data CouponViewKey
   = StoreId
   | CouponId
 
+data CouponViewImageUrl
+  = CouponImageUrl
+
 data CouponViewTypes
-  = StoreName
-  | StoreAddress
-  | ImageUrl
-  | Title
+  = Title
   | ValidFrom
   | ValidUntil
   | DiscountPercent
@@ -65,3 +70,25 @@ data CouponViewConditions
 
 data CouponViewCouponType =
   CouponType
+
+data StoreView = StoreView
+  { storeEntity :: Entity Store
+  , storeImageUrl :: Maybe Text
+  } deriving (Show, Eq)
+
+data StoreViewText
+  = StoreName
+  | StoreSalesPoint
+  | StoreAddress
+  | StorePhoneNumber
+  | StoreRegularHoliday
+  | StoreUrl
+  | StoreBusinessCategory
+
+data StoreViewImageUrl
+  = StoreImageUrl
+
+data StoreViewTexts
+  = StoreBusinessHour
+  | StoreBusinessCategoryDetails
+

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -9,6 +9,9 @@ module Kucipong.Handler.Store.Types
   , CouponViewImageUrl(..)
   , StoreView(..)
   , StoreViewImageUrl(..)
+  , StoreViewDefaultImage(..)
+  , StoreViewBusinessCategory(..)
+  , StoreViewBusinessCategoryDetails(..)
   , StoreViewText(..)
   , StoreViewTexts(..)
   ) where
@@ -74,6 +77,7 @@ data CouponViewCouponType =
 data StoreView = StoreView
   { storeEntity :: Entity Store
   , storeImageUrl :: Maybe Text
+  , storeDefaultImage :: Maybe Text
   } deriving (Show, Eq)
 
 data StoreViewText
@@ -83,12 +87,19 @@ data StoreViewText
   | StorePhoneNumber
   | StoreRegularHoliday
   | StoreUrl
-  | StoreBusinessCategory
 
 data StoreViewImageUrl
   = StoreImageUrl
 
+data StoreViewDefaultImage
+  = StoreDefaultImage
+
+data StoreViewBusinessCategory
+  = StoreBusinessCategory
+
+data StoreViewBusinessCategoryDetails
+  = StoreBusinessCategoryDetails
+
 data StoreViewTexts
   = StoreBusinessHour
-  | StoreBusinessCategoryDetails
 

--- a/src/Kucipong/View/Instance.hs
+++ b/src/Kucipong/View/Instance.hs
@@ -4,20 +4,20 @@ module Kucipong.View.Instance where
 
 import Kucipong.Prelude
 
-import Data.Default (def)
 import Database.Persist (Entity(..))
 import Database.Persist.Sql (fromSqlKey)
 
 import Kucipong.Db
-       (Coupon(..), CouponType(..), Percent, Price, Store(..),
-        percentToText, priceToText)
+       (BusinessCategory, BusinessCategoryDetail, Coupon(..),
+        CouponType(..), Percent, Price, Store(..), percentToText,
+        priceToText)
 import Kucipong.Handler.Store.Types
        (CouponView(..), CouponViewKey(..), CouponViewTypes(..),
         CouponViewConditions(..), CouponViewCouponType(..),
-        CouponViewImageUrl(..), StoreView(..),
-        StoreViewImageUrl(..),
-        StoreViewText(..), StoreViewTexts(..))
-import Kucipong.I18n (label)
+        CouponViewImageUrl(..), StoreView(..), StoreViewDefaultImage(..),
+        StoreViewImageUrl(..), StoreViewBusinessCategory(..),
+        StoreViewBusinessCategoryDetails(..), StoreViewText(..),
+        StoreViewTexts(..))
 import Kucipong.View.Class (View(..))
 
 
@@ -96,17 +96,35 @@ instance View Store StoreViewText where
   format StorePhoneNumber = fromMaybe mempty . storePhoneNumber
   format StoreRegularHoliday = fromMaybe mempty . storeRegularHoliday
   format StoreUrl = fromMaybe mempty . storeUrl
-  format StoreBusinessCategory = label def . fromMaybe minBound . storeBusinessCategory
 
 instance View Store StoreViewTexts where
   type ViewO StoreViewTexts = [Text]
   format StoreBusinessHour =
     concatMap lines . storeBusinessHours
-  format StoreBusinessCategoryDetails = map (label def) . storeBusinessCategoryDetails
+
+instance View Store StoreViewBusinessCategory where
+  type ViewO StoreViewBusinessCategory = BusinessCategory
+  format StoreBusinessCategory = fromMaybe minBound . storeBusinessCategory
+
+instance View Store StoreViewBusinessCategoryDetails where
+  type ViewO StoreViewBusinessCategoryDetails = [BusinessCategoryDetail]
+  format StoreBusinessCategoryDetails = storeBusinessCategoryDetails
 
 instance View StoreView StoreViewImageUrl where
   type ViewO StoreViewImageUrl = Text
   format StoreImageUrl = fromMaybe mempty . storeImageUrl
+
+instance View StoreView StoreViewDefaultImage where
+  type ViewO StoreViewDefaultImage = Text
+  format StoreDefaultImage = fromMaybe mempty . storeDefaultImage
+
+instance View StoreView StoreViewBusinessCategory where
+  type ViewO StoreViewBusinessCategory = BusinessCategory
+  format a = format a . entityVal . storeEntity
+
+instance View StoreView StoreViewBusinessCategoryDetails where
+  type ViewO StoreViewBusinessCategoryDetails = [BusinessCategoryDetail]
+  format a = format a . entityVal . storeEntity
 
 instance View StoreView StoreViewText where
   type ViewO StoreViewText = Text

--- a/src/Kucipong/View/Instance.hs
+++ b/src/Kucipong/View/Instance.hs
@@ -4,6 +4,7 @@ module Kucipong.View.Instance where
 
 import Kucipong.Prelude
 
+import Data.Default (def)
 import Database.Persist (Entity(..))
 import Database.Persist.Sql (fromSqlKey)
 
@@ -12,8 +13,13 @@ import Kucipong.Db
         percentToText, priceToText)
 import Kucipong.Handler.Store.Types
        (CouponView(..), CouponViewKey(..), CouponViewTypes(..),
-        CouponViewConditions(..), CouponViewCouponType(..))
+        CouponViewConditions(..), CouponViewCouponType(..),
+        CouponViewImageUrl(..), StoreView(..),
+        StoreViewImageUrl(..),
+        StoreViewText(..), StoreViewTexts(..))
+import Kucipong.I18n (label)
 import Kucipong.View.Class (View(..))
+
 
 instance View CouponView CouponViewKey where
   type ViewO CouponViewKey = Int64
@@ -22,46 +28,93 @@ instance View CouponView CouponViewKey where
 
 instance View CouponView CouponViewTypes where
   type ViewO CouponViewTypes = Text
-  format StoreName = fromMaybe "(no store name)" . storeName . store
-  format StoreAddress = fromMaybe mempty . storeAddress . store
-  format ImageUrl = fromMaybe mempty . couponImageUrl
-  format Title = couponTitle . coupon
-  format ValidFrom = maybe mempty formatValidFrom . couponValidFrom . coupon
-  format ValidUntil = maybe mempty formatValidUntil . couponValidFrom . coupon
-  format DiscountPercent =
-    maybe mempty formatDiscountPercent . couponDiscountPercent . coupon
-  format DiscountMinimumPrice =
-    maybe mempty formatCurrency . couponDiscountMinimumPrice . coupon
-  format GiftContent = maybe mempty tshow . couponGiftContent . coupon
-  format GiftMinimumPrice =
-    maybe mempty formatCurrency . couponGiftMinimumPrice . coupon
-  format GiftReferencePrice =
-    maybe mempty formatCurrency . couponGiftReferencePrice . coupon
-  format SetContent = maybe mempty tshow . couponSetContent . coupon
-  format SetPrice = maybe mempty formatCurrency . couponSetPrice . coupon
-  format SetReferencePrice =
-    maybe mempty formatCurrency . couponSetReferencePrice . coupon
-  format OtherContent = maybe mempty tshow . couponOtherContent . coupon
+  format a = format a . entityVal . couponCoupon
 
 instance View CouponView CouponViewConditions where
   type ViewO CouponViewConditions = [Text]
-  format DiscountOtherConditions =
-    concatMap lines . couponDiscountOtherConditions . coupon
-  format GiftOtherConditions =
-    concatMap lines . couponGiftOtherConditions . coupon
-  format SetOtherConditions =
-    concatMap lines . couponSetOtherConditions . coupon
-  format OtherConditions = concatMap lines . couponOtherConditions . coupon
+  format a = format a . entityVal . couponCoupon
 
 instance View CouponView CouponViewCouponType where
   type ViewO CouponViewCouponType = CouponType
-  format CouponType = couponCouponType . coupon
+  format a = format a . entityVal . couponCoupon
 
-store :: CouponView -> Store
-store = entityVal . couponStore
+instance View CouponView CouponViewImageUrl where
+  type ViewO CouponViewImageUrl = Text
+  format CouponImageUrl = fromMaybe mempty . couponImageUrl
 
-coupon :: CouponView -> Coupon
-coupon = entityVal . couponCoupon
+instance View CouponView StoreViewText where
+  type ViewO StoreViewText = Text
+  format a = format a . entityVal . couponStore
+
+-- ---------------
+--  Store coupon
+-- ---------------
+
+instance View Coupon CouponViewTypes where
+  type ViewO CouponViewTypes = Text
+  format Title = couponTitle
+  format ValidFrom = maybe mempty formatValidFrom . couponValidFrom
+  format ValidUntil = maybe mempty formatValidUntil . couponValidFrom
+  format DiscountPercent =
+    maybe mempty formatDiscountPercent . couponDiscountPercent
+  format DiscountMinimumPrice =
+    maybe mempty formatCurrency . couponDiscountMinimumPrice
+  format GiftContent = maybe mempty tshow . couponGiftContent
+  format GiftMinimumPrice =
+    maybe mempty formatCurrency . couponGiftMinimumPrice
+  format GiftReferencePrice =
+    maybe mempty formatCurrency . couponGiftReferencePrice
+  format SetContent = maybe mempty tshow . couponSetContent
+  format SetPrice = maybe mempty formatCurrency . couponSetPrice
+  format SetReferencePrice =
+    maybe mempty formatCurrency . couponSetReferencePrice
+  format OtherContent = maybe mempty tshow . couponOtherContent
+
+instance View Coupon CouponViewConditions where
+  type ViewO CouponViewConditions = [Text]
+  format DiscountOtherConditions =
+    concatMap lines . couponDiscountOtherConditions
+  format GiftOtherConditions =
+    concatMap lines . couponGiftOtherConditions
+  format SetOtherConditions =
+    concatMap lines . couponSetOtherConditions
+  format OtherConditions = concatMap lines . couponOtherConditions
+
+instance View Coupon CouponViewCouponType where
+  type ViewO CouponViewCouponType = CouponType
+  format CouponType = couponCouponType
+
+-- -------
+--  Store
+-- -------
+
+instance View Store StoreViewText where
+  type ViewO StoreViewText = Text
+  format StoreName = fromMaybe "(no store name)" . storeName
+  format StoreSalesPoint = fromMaybe mempty . storeSalesPoint
+  format StoreAddress = fromMaybe mempty . storeAddress
+  format StorePhoneNumber = fromMaybe mempty . storePhoneNumber
+  format StoreRegularHoliday = fromMaybe mempty . storeRegularHoliday
+  format StoreUrl = fromMaybe mempty . storeUrl
+  format StoreBusinessCategory = label def . fromMaybe minBound . storeBusinessCategory
+
+instance View Store StoreViewTexts where
+  type ViewO StoreViewTexts = [Text]
+  format StoreBusinessHour =
+    concatMap lines . storeBusinessHours
+  format StoreBusinessCategoryDetails = map (label def) . storeBusinessCategoryDetails
+
+instance View StoreView StoreViewImageUrl where
+  type ViewO StoreViewImageUrl = Text
+  format StoreImageUrl = fromMaybe mempty . storeImageUrl
+
+instance View StoreView StoreViewText where
+  type ViewO StoreViewText = Text
+  format a = format a . entityVal . storeEntity
+
+instance View StoreView StoreViewTexts where
+  type ViewO StoreViewTexts = [Text]
+  format a = format a . entityVal . storeEntity
 
 -- Helper functions
 formatValidFrom :: Day -> Text


### PR DESCRIPTION
This PR slims down template files related to `Kucipong.Handler.Store`.
It might be better to redirect to 404 page if store data is `Nothing`.
@cdepillabout , which do you think is better to redirect to 404 page, or show "no store" message on normal page as it is?