### PR TITLE
Make Store handlers return a 404 when a Store or Coupon is not found

### DIFF
--- a/frontend/src/pug/store/coupon_create.pug
+++ b/frontend/src/pug/store/coupon_create.pug
@@ -3,9 +3,4 @@ include ../common/_layout
     include _header
       | クーポン 新規作成
     include ../common/_messageArea
-    | %{ case mdata }
-    | %{ of Just coupon }
     include _coupon_edit
-    | %{ of Nothing }
-    | No coupon found.
-    | %{ endcase }

--- a/frontend/src/pug/store/coupon_id.pug
+++ b/frontend/src/pug/store/coupon_id.pug
@@ -2,13 +2,8 @@ include ../common/_layout
   body#main.wrapper
     include _header
       | クーポン情報
-    | %{ case mdata }
-    | %{ of Just coupon }
     .store
       .store_editBtn
         a.btn.outerBtn(href="\#{renderRoute storeCouponVarEditR couponKey}")
           | クーポン情報編集
     include ../common/_coupon_id
-    | %{ of Nothing }
-    | No coupon info.
-    | %{ endcase }

--- a/frontend/src/pug/store/coupon_id_edit.pug
+++ b/frontend/src/pug/store/coupon_id_edit.pug
@@ -3,9 +3,4 @@ include ../common/_layout
     include _header
       | クーポン情報 編集
     include ../common/_messageArea
-    | %{ case mdata }
-    | %{ of Just coupon }
     include _coupon_edit
-    | %{ of Nothing }
-    | No coupon found.
-    | %{ endcase }

--- a/frontend/src/pug/store/store.pug
+++ b/frontend/src/pug/store/store.pug
@@ -4,9 +4,6 @@ include ../common/_layout
     include _header
       | 店舗情報
     include ../common/_messageArea
-    | %{ case mdata }
-    | %{ of Just store }
-
     .store
       .store_editBtn
         a.btn.outerBtn(href="\#{renderRoute storeEditR}") 店舗情報編集
@@ -76,10 +73,3 @@ include ../common/_layout
                 | \#{format StoreRegularHoliday store}
             .storeBody_info_body_btnRow
               a.btn.outerBtn(href="\#{format StoreUrl store}") オフィシャルサイト
-
-    | %{ of Nothing }
-    | No store info.
-    | %{ endcase }
-
-
-

--- a/frontend/src/pug/store/store_edit.pug
+++ b/frontend/src/pug/store/store_edit.pug
@@ -5,8 +5,6 @@ include ../common/_layout
       | 店舗情報 編集
     include ../common/_messageArea
     form.store(enctype="multipart/form-data" method="POST")
-      | %{ case mdata }
-      | %{ of Just store }
       .storeBody
         .storeBody_info
           .storeBody_info_titleArea
@@ -131,6 +129,3 @@ include ../common/_layout
             .storeSubmit
               button.btn.outerBtn(type="submit")
                 | この内容で店舗情報を更新する
-      | %{ of Nothing }
-      | No store info.
-      | %{ endcase }

--- a/src/Kucipong/Handler/Error.hs
+++ b/src/Kucipong/Handler/Error.hs
@@ -12,7 +12,10 @@ import Web.Spock (ActionCtxT, setStatus)
 import Kucipong.RenderTemplate (renderTemplateFromEnv)
 import Kucipong.Handler.Error.TemplatePath (template404)
 
-resp404 :: MonadIO m => [Text] -> ActionCtxT ctx m ()
+resp404
+  :: forall ctx m a.
+     MonadIO m
+  => [Text] -> ActionCtxT ctx m a
 resp404 errors = do
   setStatus status404
   $(renderTemplateFromEnv template404)

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -26,10 +26,12 @@ import Kucipong.Db
 import Kucipong.Email (EmailError)
 import Kucipong.Form
        (StoreEditForm(..), StoreLoginForm(StoreLoginForm))
+import Kucipong.Handler.Error (resp404)
 import Kucipong.Handler.Route
        (storeCouponR, storeEditR, storeLoginR, storeLoginVarR, storeR)
 import Kucipong.Handler.Store.Coupon (storeCouponComponent)
 import Kucipong.Handler.Store.TemplatePath
+       (templateLogin, templateStore, templateStoreEdit)
 import Kucipong.Handler.Store.Types
        (StoreError(..), StoreMsg(..), StoreView(..), StoreViewText(..),
         StoreViewTexts(..), StoreViewBusinessCategory(..),
@@ -120,12 +122,11 @@ storeGet
 storeGet = do
   (StoreSession storeKey) <- getStoreKey
   maybeStoreEntity <- dbFindStoreByStoreKey storeKey
-  let maybeImage = storeImage . entityVal =<< maybeStoreEntity
+  storeEntity <-
+    fromMaybeM (resp404 [label def StoreErrorNoStore]) maybeStoreEntity
+  let maybeImage = storeImage $ entityVal storeEntity
   maybeImageUrl <- traverse awsImageS3Url maybeImage
-  let
-    mdata = StoreView
-      <$> maybeStoreEntity
-      <*> pure maybeImageUrl
+  let store = StoreView storeEntity maybeImageUrl
   $(renderTemplateFromEnv templateStore)
 
 storeEditGet

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -139,8 +139,8 @@ storeEditGet
 storeEditGet = do
   (StoreSession storeKey) <- getStoreKey
   maybeStoreEntity <- dbFindStoreByStoreKey storeKey
-  let
-    mdata = maybeStoreEntity
+  store <-
+    fromMaybeM (resp404 [label def StoreErrorNoStore]) maybeStoreEntity
   $(renderTemplateFromEnv templateStoreEdit)
 
 storeEditPost
@@ -188,9 +188,7 @@ storeEditPost = do
       filter (isValidBusinessCategoryDetailFor busiCat) busiCatDets
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
-      p <- params
-      let
-        mdata = pure p
+      store <- params
       $(logDebug) $ "got following error in storeEditPost handler: " <> errMsg
       let errors = [errMsg]
       $(renderTemplateFromEnv templateStoreEdit)

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -27,7 +27,7 @@ data StoreError
   | StoreErrorCouldNotSendEmail
   | StoreErrorCouldNotUploadImage
   | StoreErrorCouponNotFound
-  | StoreErrorNoImage
+  | StoreErrorNoStore
   | StoreErrorNoStoreEmail EmailAddress
   | StoreErrorNotAnImage
   deriving (Show, Eq, Ord, Read)

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -71,8 +71,8 @@ instance I18n StoreError where
     "Could not upload image. Please try again."
   label EnUS StoreErrorCouponNotFound =
     "Could not find the specified coupon."
-  label EnUS StoreErrorNoImage =
-    "Failed to upload image. Please try again."
+  label EnUS StoreErrorNoStore =
+    "Store not found."
   label EnUS (StoreErrorNoStoreEmail email) =
     "Could not find store for email " <> tshow email <> "."
   label EnUS StoreErrorNotAnImage =


### PR DESCRIPTION
This PR makes the `Store` handlers return a 404 when the `Store` or `Coupon` is not found.

This also cleans up some of the templates so that they don't have to worry about a store being `Nothing`.

This closes #162.