### PR TITLE
Add JSON APIs for upserting images for stores and coupons

### DIFF
--- a/frontend/src/pug/common/_couponSimple.pug
+++ b/frontend/src/pug/common/_couponSimple.pug
@@ -2,7 +2,7 @@
   a.card(href="\#{renderRoute storeCouponVarR couponKey}")
     .annotatedImageGroup
       img.annotatedImageGroup-image(
-        src="\#{ fromMaybe mempty (awsImageUrlFunc (couponImage coupon))}"
+        src="\#{ fromMaybe mempty (awsImageUrlFunc maybeImageEntity)}"
         alt="\#{ couponTitle coupon }"
       )
       span.annotatedImageGroup-annotation 画像は一例です

--- a/frontend/src/pug/store/coupon.pug
+++ b/frontend/src/pug/store/coupon.pug
@@ -6,11 +6,11 @@ include ../common/_layout
       .store_editBtn
         a.btn.outerBtn(href="\#{renderRoute storeCouponCreateR}") クーポン追加
 
-    | %{ case couponEntities }
+    | %{ case couponEntitiesAndImages }
     | %{ of [] }
     |   No Coupons
     | %{ of entities }
-    |   %{ forall (Entity couponKey coupon) <- entities }
+    |   %{ forall (Entity couponKey coupon, maybeImageEntity) <- entities }
     include ../common/_couponSimple
     |   %{ endforall }
     | %{ endcase }

--- a/kucipong.cabal
+++ b/kucipong.cabal
@@ -78,6 +78,7 @@ library
                      , Kucipong.RenderTemplate
                      , Kucipong.Session
                      , Kucipong.Spock
+                     , Kucipong.Spock.Json
                      , Kucipong.Spock.ReqParam
                      , Kucipong.Util
                      , Kucipong.View

--- a/src/Kucipong/Db/Models.hs
+++ b/src/Kucipong/Db/Models.hs
@@ -74,6 +74,15 @@ instance EntityDateFields Coupon where
   getDeletedEntityFieldValue = couponDeleted
   getUpdatedEntityFieldValue = couponUpdated
 
+instance EntityDateFields Image where
+  createdEntityField = ImageCreated
+  deletedEntityField = ImageDeleted
+  updatedEntityField = ImageUpdated
+
+  getCreatedEntityFieldValue = imageCreated
+  getDeletedEntityFieldValue = imageDeleted
+  getUpdatedEntityFieldValue = imageUpdated
+
 instance EntityDateFields Store where
   createdEntityField = StoreCreated
   deletedEntityField = StoreDeleted

--- a/src/Kucipong/Db/Models/Base.hs
+++ b/src/Kucipong/Db/Models/Base.hs
@@ -110,8 +110,8 @@ newtype DeletedTime = DeletedTime
 -- Image --
 -----------
 
-newtype Image = Image
-  { unImage :: Text
+newtype ImageName = ImageName
+  { unImageName :: Text
   } deriving ( Data
              , Eq
              , FromHttpApiData

--- a/src/Kucipong/Db/Models/EntityDefs.hs
+++ b/src/Kucipong/Db/Models/EntityDefs.hs
@@ -8,7 +8,7 @@ import Database.Persist ( EntityDef )
 import Database.Persist.TH ( persistLowerCase )
 
 import Kucipong.Db.Models.Base
-       (BusinessCategory, CouponType, CreatedTime, DeletedTime, Image,
+       (BusinessCategory, CouponType, CreatedTime, DeletedTime, ImageName,
         LoginTokenExpirationTime, Percent, Price, UpdatedTime)
 import Kucipong.LoginToken ( LoginToken )
 
@@ -49,7 +49,7 @@ kucipongEntityDefs = [persistLowerCase|
         name                    Text Maybe
         businessCategory        BusinessCategory Maybe
         businessCategoryDetails [BusinessCategoryDetail]
-        image                   Image Maybe
+        image                   ImageId Maybe
         salesPoint              Text Maybe
         address                 Text Maybe
         phoneNumber             Text Maybe
@@ -84,7 +84,7 @@ kucipongEntityDefs = [persistLowerCase|
         couponType              CouponType
         validFrom               Day Maybe
         validUntil              Day Maybe
-        image                   Image Maybe
+        image                   ImageId Maybe
         discountPercent         Percent Maybe
         discountMinimumPrice    Price Maybe
         discountOtherConditions Text Maybe
@@ -102,4 +102,16 @@ kucipongEntityDefs = [persistLowerCase|
         deriving Eq
         deriving Show
         deriving Typeable
+
+    Image
+        created                 CreatedTime
+        updated                 UpdatedTime
+        deleted                 DeletedTime Maybe
+        storeId                 StoreId
+        s3Name                  ImageName
+
+        deriving Eq
+        deriving Show
+        deriving Typeable
+
     |]

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -107,6 +107,7 @@ data StoreNewCouponForm = StoreNewCouponForm
   , couponType :: CouponType
   , validFrom :: !(MaybeEmpty Day)
   , validUntil :: !(MaybeEmpty Day)
+  , imageKey :: !(MaybeEmpty (Key Image))
   , discountPercent :: !(MaybeEmpty Percent)
   , discountMinimumPrice :: !(MaybeEmpty Price)
   , discountOtherConditions :: !(MaybeEmpty Text)
@@ -120,7 +121,7 @@ data StoreNewCouponForm = StoreNewCouponForm
   , setOtherConditions :: !(MaybeEmpty Text)
   , otherContent :: !(MaybeEmpty Text)
   , otherConditions :: !(MaybeEmpty Text)
-  } deriving (Data, Eq, Generic, Read, Show, Typeable)
+  } deriving (Eq, Generic, Read, Show, Typeable)
 
 $(makeLensesFor
     [ ("discountPercent", "discountPercentLens")

--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -13,12 +13,13 @@ import Kucipong.Prelude
 
 import Control.Lens ((.~))
 import Control.Lens.TH (makeLensesFor, makeWrapped)
+import Data.Aeson.TH (defaultOptions, deriveJSON)
 import Web.FormUrlEncoded (FromForm)
 import Web.HttpApiData (FromHttpApiData(..))
 
 import Kucipong.Db
-       (BusinessCategory(..), BusinessCategoryDetail(..),
-        CouponType(..), Percent(..), Price(..))
+       (BusinessCategory(..), BusinessCategoryDetail(..), Image(..),
+        Key(..), CouponType(..), Percent(..), Price(..))
 
 newtype MaybeEmpty a = MaybeEmpty
   { unMaybeEmpty :: Maybe a
@@ -80,15 +81,22 @@ data StoreEditForm = StoreEditForm
   { name :: !(Maybe Text)
   , businessCategory :: !(Maybe BusinessCategory)
   , businessCategoryDetails :: ![BusinessCategoryDetail]
+  , imageKey :: !(Maybe (Key Image))
   , salesPoint :: !(Maybe Text)
   , address :: !(Maybe Text)
   , phoneNumber :: !(Maybe Text)
   , businessHours :: !(Maybe Text)
   , regularHoliday :: !(Maybe Text)
   , url :: !(Maybe Text)
-  } deriving (Data, Eq, Generic, Read, Show, Typeable)
+  } deriving (Eq, Generic, Read, Show, Typeable)
 
 instance FromForm StoreEditForm
+
+data StoreSetImageForm = StoreSetImageForm
+  { imageKey :: !(Maybe (Key Image))
+  } deriving (Eq, Generic, Read, Show, Typeable)
+
+$(deriveJSON defaultOptions ''StoreSetImageForm)
 
 ------------------
 -- Store Coupon --

--- a/src/Kucipong/Handler/Route.hs
+++ b/src/Kucipong/Handler/Route.hs
@@ -29,11 +29,17 @@ deleteR = "delete"
 editR :: Path '[] 'Open
 editR = "edit"
 
+imageR :: Path '[] 'Open
+imageR = "image"
+
 loginR :: Path '[] 'Open
 loginR = "login"
 
 rootR :: Path '[] 'Open
 rootR = ""
+
+setR :: Path '[] 'Open
+setR = "set"
 
 staticR :: Path '[] 'Open
 staticR = "static"
@@ -84,14 +90,23 @@ storeCouponVarR = storeR <//> couponR <//> var
 storeCouponVarEditR :: Path '[Key Coupon] 'Open
 storeCouponVarEditR = storeR <//> couponR <//> var <//> editR
 
+storeCouponVarSetImageR :: Path '[Key Coupon] 'Open
+storeCouponVarSetImageR = storeR <//> couponR <//> var <//> setR <//> imageR
+
 storeEditR :: Path '[] 'Open
 storeEditR = storeR <//> editR
+
+storeImageR :: Path '[] 'Open
+storeImageR = storeR <//> imageR
 
 storeLoginR :: Path '[] 'Open
 storeLoginR = storeR <//> loginR
 
 storeLoginVarR :: Path '[LoginToken] 'Open
 storeLoginVarR = storeR <//> loginR <//> var
+
+storeSetImageR :: Path '[] 'Open
+storeSetImageR = storeR <//> setR <//> imageR
 
 consumerCouponVarR :: Path '[Key Coupon] 'Open
 consumerCouponVarR = consumerR <//> couponR <//> var

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -15,15 +15,14 @@ import Data.HVect (HVect(..))
 import Database.Persist (Entity(..))
 import Network.HTTP.Types.Status
        (badRequest400, serviceUnavailable503)
-import Network.Wai (strictRequestBody)
 import Web.Spock
        (ActionCtxT, getContext, params, prehook, redirect, renderRoute)
 import Web.Spock.Core
-       (SpockCtxT, body, get, files, jsonBody', post, put, request)
+       (SpockCtxT, get, files, jsonBody', post)
 
 import Kucipong.Db
-       (BusinessCategory(..), BusinessCategoryDetail(..), Image(..),
-        ImageName(..), Key(..), LoginTokenExpirationTime(..), Store(..),
+       (BusinessCategory(..), BusinessCategoryDetail(..), Key(..),
+        LoginTokenExpirationTime(..), Store(..),
         StoreLoginToken(storeLoginTokenExpirationTime,
                         storeLoginTokenLoginToken),
         isValidBusinessCategoryDetailFor,
@@ -49,10 +48,9 @@ import Kucipong.I18n (label)
 import Kucipong.LoginToken (LoginToken)
 import Kucipong.Monad
        (FileUploadError(..), MonadKucipongAws(..), MonadKucipongCookie,
-        MonadKucipongDb(..), MonadKucipongSendEmail(..), awsImageS3Url,
-        dbFindImage, dbFindImageWithStoreKey, dbFindStoreByEmail, dbFindStoreByStoreKey,
-        dbFindStoreLoginToken, dbInsertImage, dbUpdateStore,
-        dbUpdateStoreImage)
+        MonadKucipongDb(..), MonadKucipongSendEmail(..),
+        dbFindStoreByEmail, dbFindStoreByStoreKey, dbFindStoreLoginToken,
+        dbInsertImage, dbUpdateStore, dbUpdateStoreImage)
 import Kucipong.RenderTemplate
        (renderTemplateFromEnv)
 import Kucipong.Session (Session, SessionType(SessionTypeStore))
@@ -203,9 +201,7 @@ storeSetImagePost
   :: forall n xs m.
      ( ContainsStoreSession n xs
      , MonadIO m
-     , MonadKucipongAws m
      , MonadKucipongDb m
-     , MonadLogger m
      )
   => ActionCtxT (HVect xs) m ()
 storeSetImagePost = do

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -6,29 +6,36 @@ module Kucipong.Handler.Store
 
 import Kucipong.Prelude
 
-import Control.FromSum (fromMaybeM)
+import Control.FromSum (fromEitherM, fromMaybeM)
 import Control.Monad.Time (MonadTime(..))
+import Data.Aeson (ToJSON(toJSON), Value(String))
 import Data.Default (def)
 import Data.List (nub)
 import Data.HVect (HVect(..))
 import Database.Persist (Entity(..))
+import Network.HTTP.Types.Status
+       (badRequest400, serviceUnavailable503)
+import Network.Wai (strictRequestBody)
 import Web.Spock
        (ActionCtxT, getContext, params, prehook, redirect, renderRoute)
-import Web.Spock.Core (SpockCtxT, get, post)
+import Web.Spock.Core
+       (SpockCtxT, body, get, files, jsonBody', post, put, request)
 
 import Kucipong.Db
-       (BusinessCategory(..), BusinessCategoryDetail(..), Key(..),
-        LoginTokenExpirationTime(..), Store(..),
+       (BusinessCategory(..), BusinessCategoryDetail(..), Image(..),
+        ImageName(..), Key(..), LoginTokenExpirationTime(..), Store(..),
         StoreLoginToken(storeLoginTokenExpirationTime,
                         storeLoginTokenLoginToken),
         isValidBusinessCategoryDetailFor,
         unfoldAllBusinessCategoryDetailAlt)
 import Kucipong.Email (EmailError)
 import Kucipong.Form
-       (StoreEditForm(..), StoreLoginForm(StoreLoginForm))
+       (StoreEditForm(..), StoreLoginForm(StoreLoginForm),
+        StoreSetImageForm(StoreSetImageForm))
 import Kucipong.Handler.Error (resp404)
 import Kucipong.Handler.Route
-       (storeCouponR, storeEditR, storeLoginR, storeLoginVarR, storeR)
+       (storeCouponR, storeEditR, storeImageR, storeLoginR,
+        storeLoginVarR, storeR, storeSetImageR)
 import Kucipong.Handler.Store.Coupon (storeCouponComponent)
 import Kucipong.Handler.Store.TemplatePath
        (templateLogin, templateStore, templateStoreEdit)
@@ -36,19 +43,23 @@ import Kucipong.Handler.Store.Types
        (StoreError(..), StoreMsg(..), StoreView(..), StoreViewText(..),
         StoreViewTexts(..), StoreViewBusinessCategory(..),
         StoreViewBusinessCategoryDetails(..), StoreViewImageUrl(..))
+import Kucipong.Handler.Store.Util
+       (awsUrlFromMaybeImageKey, guardMaybeImageKeyOwnedByStore)
 import Kucipong.I18n (label)
 import Kucipong.LoginToken (LoginToken)
 import Kucipong.Monad
-       (MonadKucipongAws(..), MonadKucipongCookie,
+       (FileUploadError(..), MonadKucipongAws(..), MonadKucipongCookie,
         MonadKucipongDb(..), MonadKucipongSendEmail(..), awsImageS3Url,
-        dbFindStoreByEmail, dbFindStoreByStoreKey, dbFindStoreLoginToken,
-        dbUpdateStore)
+        dbFindImage, dbFindImageWithStoreKey, dbFindStoreByEmail, dbFindStoreByStoreKey,
+        dbFindStoreLoginToken, dbInsertImage, dbUpdateStore,
+        dbUpdateStoreImage)
 import Kucipong.RenderTemplate
        (renderTemplateFromEnv)
 import Kucipong.Session (Session, SessionType(SessionTypeStore))
 import Kucipong.Spock
        (pattern StoreSession, ContainsStoreSession, getReqParamErr,
-        getStoreCookie, getStoreKey, setStoreCookie)
+        getStoreCookie, getStoreKey, jsonErrorStatus, jsonSuccess,
+        setStoreCookie)
 
 -- | Handler for returning the store login page.
 loginGet
@@ -124,8 +135,8 @@ storeGet = do
   maybeStoreEntity <- dbFindStoreByStoreKey storeKey
   storeEntity <-
     fromMaybeM (resp404 [label def StoreErrorNoStore]) maybeStoreEntity
-  let maybeImage = storeImage $ entityVal storeEntity
-  maybeImageUrl <- traverse awsImageS3Url maybeImage
+  let maybeImageKey = storeImage $ entityVal storeEntity
+  maybeImageUrl <- awsUrlFromMaybeImageKey maybeImageKey
   let store = StoreView storeEntity maybeImageUrl
   $(renderTemplateFromEnv templateStore)
 
@@ -143,6 +154,74 @@ storeEditGet = do
     fromMaybeM (resp404 [label def StoreErrorNoStore]) maybeStoreEntity
   $(renderTemplateFromEnv templateStoreEdit)
 
+data ImgPostErr
+  = ImgPostErrNoImg
+  | ImgPostErr FileUploadError
+  deriving (Show, Typeable)
+
+instance ToJSON ImgPostErr where
+  toJSON :: ImgPostErr -> Value
+  toJSON ImgPostErrNoImg = String "ImgPostErrNoImg"
+  toJSON (ImgPostErr fileUploadError) = toJSON fileUploadError
+
+storeImagePost
+  :: forall n xs m.
+     ( ContainsStoreSession n xs
+     , MonadIO m
+     , MonadKucipongAws m
+     , MonadKucipongDb m
+     )
+  => ActionCtxT (HVect xs) m ()
+storeImagePost = do
+  (StoreSession storeKey) <- getStoreKey
+  filesHashMap <- files
+  print filesHashMap
+  uploadedImage <-
+    fromMaybeM (handleErr ImgPostErrNoImg) $ lookup "image" filesHashMap
+  eitherImageName <- first ImgPostErr <$> awsS3PutUploadedFile uploadedImage
+  s3ImageName <- fromEitherM handleErr eitherImageName
+  (Entity imageKey _) <- dbInsertImage storeKey s3ImageName
+  jsonSuccess imageKey
+  where
+    handleErr :: ImgPostErr -> ActionCtxT (HVect xs) m a
+    handleErr err@ImgPostErrNoImg =
+      jsonErrorStatus badRequest400 err "image not found in upload"
+    handleErr err@(ImgPostErr (AwsError _)) =
+      jsonErrorStatus serviceUnavailable503 err "error with aws"
+    handleErr err@(ImgPostErr FileContentTypeError) =
+      jsonErrorStatus
+        badRequest400
+        err
+        "content type of the image is not supported"
+    handleErr err@(ImgPostErr (FileReadError _)) =
+      jsonErrorStatus
+        serviceUnavailable503
+        err
+        "server error with reading the file uploaded"
+
+storeSetImagePost
+  :: forall n xs m.
+     ( ContainsStoreSession n xs
+     , MonadIO m
+     , MonadKucipongAws m
+     , MonadKucipongDb m
+     , MonadLogger m
+     )
+  => ActionCtxT (HVect xs) m ()
+storeSetImagePost = do
+  (StoreSession storeKey) <- getStoreKey
+  StoreSetImageForm maybeImageKey <- jsonBody'
+  guardMaybeImageKeyOwnedByStore storeKey maybeImageKey handleErr
+  void $ dbUpdateStoreImage storeKey maybeImageKey
+  jsonSuccess maybeImageKey
+  where
+    handleErr :: ActionCtxT (HVect xs) m a
+    handleErr =
+      jsonErrorStatus
+        badRequest400
+        StoreErrorImageOwnedByStore
+        (label def StoreErrorImageOwnedByStore)
+
 storeEditPost
   :: forall xs n m.
      ( ContainsStoreSession n xs
@@ -156,6 +235,7 @@ storeEditPost = do
   StoreEditForm { name
                 , businessCategory
                 , businessCategoryDetails
+                , imageKey
                 , salesPoint
                 , address
                 , phoneNumber
@@ -165,12 +245,15 @@ storeEditPost = do
                 } <- getReqParamErr handleErr
   let businessCategoryDetails' =
         filterBusinessCategoryDetails businessCategory businessCategoryDetails
+  guardMaybeImageKeyOwnedByStore storeKey imageKey $
+    handleErr (label def StoreErrorImageOwnedByStore)
   void $
     dbUpdateStore
       storeKey
       name
       businessCategory
       (nub businessCategoryDetails')
+      imageKey
       salesPoint
       address
       phoneNumber
@@ -186,6 +269,7 @@ storeEditPost = do
     filterBusinessCategoryDetails Nothing _ = []
     filterBusinessCategoryDetails (Just busiCat) busiCatDets =
       filter (isValidBusinessCategoryDetailFor busiCat) busiCatDets
+
     handleErr :: Text -> ActionCtxT (HVect xs) m a
     handleErr errMsg = do
       store <- params
@@ -223,6 +307,8 @@ storeComponent = do
     get storeR storeGet
     get storeEditR storeEditGet
     post storeEditR storeEditPost
+    post storeImageR storeImagePost
+    post storeSetImageR storeSetImagePost
     storeCouponComponent
 
 allBusinessCategories :: [BusinessCategory]

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -117,6 +117,7 @@ couponEditPost couponKey = do
       couponType
       (view _Wrapped validFrom)
       (view _Wrapped validUntil)
+      (view _Wrapped imageKey)
       (view _Wrapped discountPercent)
       (view _Wrapped discountMinimumPrice)
       (view _Wrapped discountOtherConditions)
@@ -179,6 +180,7 @@ couponPost = do
       couponType
       (view _Wrapped validFrom)
       (view _Wrapped validUntil)
+      (view _Wrapped imageKey)
       (view _Wrapped discountPercent)
       (view _Wrapped discountMinimumPrice)
       (view _Wrapped discountOtherConditions)

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -9,15 +9,13 @@ import Control.Lens (_Wrapped, view)
 import Data.Default (def)
 import Data.HVect (HVect(..))
 import Database.Persist.Sql (Entity(..), fromSqlKey)
-import Network.HTTP.Types.Status
-       (badRequest400, serviceUnavailable503)
+import Network.HTTP.Types.Status (badRequest400)
 import Web.Spock (ActionCtxT, params, redirect, renderRoute)
 import Web.Spock.Core
        (ClientPreferredFormat(PrefJSON), SpockCtxT, get, json, jsonBody',
         preferredFormat, post)
 
-import Kucipong.Db
-       (Coupon(..), CouponType(..), Image(..), Key(..), Store(..))
+import Kucipong.Db (Coupon(..), CouponType(..), Image(..), Key(..))
 import Kucipong.Form
        (StoreNewCouponForm(..), StoreSetImageForm(..),
         removeNonUsedCouponInfo)
@@ -39,11 +37,10 @@ import Kucipong.Handler.Types (PageViewer(..))
 import Kucipong.I18n (label)
 import Kucipong.Monad
        (CouponDeleteResult(..), MonadKucipongAws(..), MonadKucipongDb(..),
-        awsGetBucketName, awsImageS3Url, awsUrlFromImageAndBucket,
+        awsGetBucketName, awsUrlFromImageAndBucket,
         dbFindCouponByStoreKeyAndCouponKey, dbFindCouponsByStoreKey,
-        dbFindImageWithStoreKey, dbFindImagesForCoupons,
-        dbFindStoreByStoreKey, dbInsertCoupon, dbUpdateCoupon,
-        dbUpdateCouponImage)
+        dbFindImagesForCoupons, dbFindStoreByStoreKey, dbInsertCoupon,
+        dbUpdateCoupon, dbUpdateCouponImage)
 import Kucipong.RenderTemplate (renderTemplateFromEnv)
 import Kucipong.Session (Session, SessionType(SessionTypeStore))
 import Kucipong.Spock
@@ -251,9 +248,7 @@ couponSetImagePost
   :: forall n xs m.
      ( ContainsStoreSession n xs
      , MonadIO m
-     , MonadKucipongAws m
      , MonadKucipongDb m
-     , MonadLogger m
      )
   => Key Coupon -> ActionCtxT (HVect xs) m ()
 couponSetImagePost couponKey = do

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Kucipong.Handler.Store.Types
   ( StoreError(..)
   , StoreMsg(..)
@@ -17,6 +19,7 @@ module Kucipong.Handler.Store.Types
 
 import Kucipong.Prelude
 
+import Data.Aeson.TH (defaultOptions, deriveJSON)
 import Database.Persist (Entity(..))
 
 import Kucipong.Db (Coupon(..), Store(..))
@@ -27,10 +30,13 @@ data StoreError
   | StoreErrorCouldNotSendEmail
   | StoreErrorCouldNotUploadImage
   | StoreErrorCouponNotFound
+  | StoreErrorImageOwnedByStore
   | StoreErrorNoStore
   | StoreErrorNoStoreEmail EmailAddress
   | StoreErrorNotAnImage
   deriving (Show, Eq, Ord, Read)
+
+$(deriveJSON defaultOptions ''StoreError)
 
 data StoreMsg =
   StoreMsgSentVerificationEmail

--- a/src/Kucipong/Handler/Store/Util.hs
+++ b/src/Kucipong/Handler/Store/Util.hs
@@ -1,106 +1,31 @@
-module Kucipong.Handler.Store.Util
-  ( uploadImgToS3WithDef
-  , UploadImgErr(..)
-  ) where
+
+module Kucipong.Handler.Store.Util where
 
 import Kucipong.Prelude
 
-import Data.HVect (HVect(..))
-import Web.Spock (ActionCtxT, UploadedFile(..), files)
+import Database.Persist (entityVal)
 
-import Kucipong.Db (Image(..))
-import Kucipong.Monad (FileUploadError(..), MonadKucipongAws(..))
+import Kucipong.Db (Image(imageS3Name), Key, Store)
+import Kucipong.Monad
+       (MonadKucipongAws, MonadKucipongDb, awsImageS3Url, dbFindImage,
+        dbFindImageWithStoreKey)
 
-data UploadImgErr = UploadImgErr UploadedFile FileUploadError
-  deriving (Show, Typeable)
+awsUrlFromMaybeImageKey
+  :: (MonadKucipongAws m, MonadKucipongDb m)
+  => Maybe (Key Image) -> m (Maybe Text)
+awsUrlFromMaybeImageKey Nothing = pure Nothing
+awsUrlFromMaybeImageKey (Just imageKey) = do
+  maybeImageEntity <- dbFindImage imageKey
+  let maybeImageName = imageS3Name . entityVal <$> maybeImageEntity
+  traverse awsImageS3Url maybeImageName
 
--- | Upload the @\"image\"@ in 'files' to S3.  If the 'Maybe' 'Text' argument
--- is 'Just', then use that as the 'Image' url and don't try to upload anything
--- to S3.
---
--- The return type of this function is somewhat complex.
---
--- If the default 'Image' url argument ('Maybe' 'Text') is 'Nothing', and the
--- user has not uploaded a file called @\"image\"@, then this function will
--- return @'Right' 'Nothing'@.  This indicates that the user doesn\'t want to
--- use an image.
---
--- If the default 'Image' url argument ('Maybe' 'Text') is @'Just' \"\"@, and
--- the user has not uploaded a file called @\"image\"@, then this function will
--- return @'Right' 'Nothing'@.  This also indicates that the user doesn\'t want
--- to use an image.
---
--- If the default 'Image' url argument ('Maybe' 'Text') is @'Just' imageName@
--- (where @imagename@ is anything other than the empty string), and the user
--- has not uploaded a file called @\"image\"@, then this function will return
--- @'Right' ('Just' @imageName@), with the @imageName@ being the default
--- 'Image' url.
---
--- If the user has uploaded a file called @\"image\"@, then this function will
--- try to upload it to S3.  If it fails, it will return @'Left' 'UploadImgErr'@.
--- If it succeeds, it will return @'Right' ('Just' image)@.
--- doesn't exist, then return 'Right' 'Nothing'.
-uploadImgToS3WithDef
-  :: forall xs m.
-     (MonadIO m, MonadKucipongAws m)
-  => Maybe Image -- ^ Default 'Image' url.
-  -> ActionCtxT (HVect xs) m (Either UploadImgErr (Maybe Image))
-uploadImgToS3WithDef maybeDefaultImage = do
-  filesHashMap <- files
-  let maybeUploadedImage = lookupImage filesHashMap
-  print maybeDefaultImage
-  print maybeUploadedImage
-  print filesHashMap
-  handleImages maybeDefaultImage maybeUploadedImage
-  where
-    handleImages
-      :: Maybe Image
-      -> Maybe UploadedFile
-      -> ActionCtxT (HVect xs) m (Either UploadImgErr (Maybe Image))
-    handleImages Nothing Nothing =
-      pure $ Right Nothing
-    handleImages (Just (Image "")) Nothing =
-      pure $ Right Nothing
-    handleImages (Just defaultImage) Nothing =
-      pure . Right $ Just defaultImage
-    handleImages _ (Just uploadedImage) =
-      awsS3PutUploadedFile uploadedImage >>=
-      either (pure . Left . UploadImgErr uploadedImage) (pure . Right . Just)
+guardMaybeImageKeyOwnedByStore
+  :: MonadKucipongDb m
+  => Key Store -> Maybe (Key Image) -> m () -> m ()
+guardMaybeImageKeyOwnedByStore _ Nothing _ = pure ()
+guardMaybeImageKeyOwnedByStore storeKey (Just imageKey) actionIfBad = do
+  maybeImageEntity <- dbFindImageWithStoreKey storeKey imageKey
+  case maybeImageEntity of
+    Just _ -> pure ()
+    Nothing -> actionIfBad
 
--- | Lookup a file called @\"image\"@ in the uploaded files 'HashMap'.
---
--- If there no file called @\"image\"@, then return 'Nothing'.
---
--- >>> lookupImage $ mapFromList []
--- Nothing
---
--- If there is a file called @\"image\"@, but it matches the
--- 'EmptyUploadedFile' pattern, then return 'Nothing'.
---
--- >>> let uf_name = "\"\""
--- >>> let uf_contentType = "application/octet-stream"
--- >>> let uf_tempLocation = ""
--- >>> let uploadedFile = UploadedFile{..}
--- >>> lookupImage $ mapFromList [("image", uploadedFile)]
--- Nothing
---
--- If there is a file called @\"image\"@, and it doesn't match the
--- 'EmptyUploadedfile' pattern (that is, it is a real uploaded file), then
--- return 'Just' of that file.
---
--- >>> let uf_name = "name.jpg"
--- >>> let uf_contentType = "image/jpg"
--- >>> let uf_tempLocation = "somelocation.file"
--- >>> let uploadedFile = UploadedFile{..}
--- >>> lookupImage $ mapFromList [("image", uploadedFile)]
--- Just ...
-lookupImage :: HashMap Text UploadedFile -> Maybe UploadedFile
-lookupImage filesHashMap = lookup "image" filesHashMap >>= \case
-  EmptyUploadedFile -> Nothing
-  uploadedfile -> Just uploadedfile
-
--- | This pattern matches an 'UploadedFile' where the user hasn't actually
--- uploaded a file.
-pattern EmptyUploadedFile :: UploadedFile
-pattern EmptyUploadedFile <-
-  UploadedFile {uf_name = "\"\"", uf_contentType = "application/octet-stream"}

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -71,6 +71,8 @@ instance I18n StoreError where
     "Could not upload image. Please try again."
   label EnUS StoreErrorCouponNotFound =
     "Could not find the specified coupon."
+  label EnUS StoreErrorImageOwnedByStore =
+    "Image not owned by store."
   label EnUS StoreErrorNoStore =
     "Store not found."
   label EnUS (StoreErrorNoStoreEmail email) =

--- a/src/Kucipong/Monad/Aws/Class.hs
+++ b/src/Kucipong/Monad/Aws/Class.hs
@@ -5,11 +5,12 @@ module Kucipong.Monad.Aws.Class where
 import Kucipong.Prelude
 
 import Control.Monad.Trans (MonadTrans)
+import Data.Aeson (ToJSON(toJSON), Value(String))
 import Network.AWS (Error)
 import Web.Spock (ActionCtxT, UploadedFile)
 
 import Kucipong.Aws (S3ImageBucketName(..))
-import Kucipong.Db (Image(..))
+import Kucipong.Db (ImageName(..))
 import Kucipong.Monad.Cookie.Trans (KucipongCookieT)
 import Kucipong.Monad.Db.Trans (KucipongDbT)
 import Kucipong.Monad.SendEmail.Trans (KucipongSendEmailT)
@@ -20,19 +21,25 @@ data FileUploadError
   | FileReadError IOException
   deriving (Generic, Show, Typeable)
 
+instance ToJSON FileUploadError where
+  toJSON :: FileUploadError -> Value
+  toJSON (AwsError _) = String "AwsError"
+  toJSON FileContentTypeError = String "FileContentTypeError"
+  toJSON (FileReadError _) = String "FileReadError"
+
 -- |
 -- Default implementations are used to easily derive instances for monads
 -- transformers that implement 'MonadTrans'.
 class Monad m => MonadKucipongAws m where
   awsS3PutUploadedFile
     :: UploadedFile
-    -> m (Either FileUploadError Image)
+    -> m (Either FileUploadError ImageName)
   default awsS3PutUploadedFile
     :: ( MonadKucipongAws n
        , MonadTrans t
        , m ~ t n
        )
-    => UploadedFile -> t n (Either FileUploadError Image)
+    => UploadedFile -> t n (Either FileUploadError ImageName)
   awsS3PutUploadedFile = lift . awsS3PutUploadedFile
 
   awsGetBucketName :: m S3ImageBucketName
@@ -52,11 +59,11 @@ instance MonadKucipongAws m => MonadKucipongAws (KucipongDbT m)
 instance MonadKucipongAws m => MonadKucipongAws (KucipongSendEmailT m)
 instance MonadKucipongAws m => MonadKucipongAws (ReaderT r m)
 
-awsImageS3Url :: MonadKucipongAws m => Image -> m Text
+awsImageS3Url :: MonadKucipongAws m => ImageName -> m Text
 awsImageS3Url image = do
   bucketName <- awsGetBucketName
   pure $ awsUrlFromImageAndBucket bucketName image
 
-awsUrlFromImageAndBucket :: S3ImageBucketName -> Image -> Text
-awsUrlFromImageAndBucket (S3ImageBucketName bucketName) (Image s3FileName) =
+awsUrlFromImageAndBucket :: S3ImageBucketName -> ImageName -> Text
+awsUrlFromImageAndBucket (S3ImageBucketName bucketName) (ImageName s3FileName) =
   "https://s3-ap-northeast-1.amazonaws.com/" <> bucketName <> "/" <> s3FileName

--- a/src/Kucipong/Monad/Aws/Instance.hs
+++ b/src/Kucipong/Monad/Aws/Instance.hs
@@ -21,7 +21,7 @@ import Web.Spock (UploadedFile(..))
 
 import Kucipong.Aws
        (HasS3ImageBucketName(..), S3ImageBucketName(..), getAwsBucketM)
-import Kucipong.Db (Image(..))
+import Kucipong.Db (ImageName(..))
 import Kucipong.Monad.Aws.Class
        (FileUploadError(..), MonadKucipongAws(..))
 import Kucipong.Monad.Aws.Trans (KucipongAwsT(..))
@@ -35,7 +35,7 @@ instance ( HasEnv r
          ) =>
          MonadKucipongAws (KucipongAwsT m) where
   awsS3PutUploadedFile :: UploadedFile
-                       -> KucipongAwsT m (Either FileUploadError Image)
+                       -> KucipongAwsT m (Either FileUploadError ImageName)
   awsS3PutUploadedFile uploadedFile =
     runExceptT $ do
       bucket <- getAwsBucketM
@@ -48,7 +48,7 @@ instance ( HasEnv r
             putObject bucket objectKey reqBody
               & poACL .~ Just OPublicRead
               & poContentType .~ Just contentType
-      const (Image s3FileName) <$> runReq putObjectReq
+      const (ImageName s3FileName) <$> runReq putObjectReq
 
   awsGetBucketName :: KucipongAwsT m S3ImageBucketName
   awsGetBucketName = reader getS3ImageBucketName

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -529,6 +529,7 @@ dbInsertCoupon
   -> CouponType
   -> Maybe Day
   -> Maybe Day
+  -> Maybe (Key Image)
   -> Maybe Percent
   -> Maybe Price
   -> Maybe Text
@@ -543,7 +544,7 @@ dbInsertCoupon
   -> Maybe Text
   -> Maybe Text
   -> m (Entity Coupon)
-dbInsertCoupon storeKey title couponType validFrom validUntil discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
+dbInsertCoupon storeKey title couponType validFrom validUntil imageKey discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
   dbInsertWithTime $ \createdTime updatedTime deletedTime ->
     Coupon
       storeKey
@@ -554,7 +555,7 @@ dbInsertCoupon storeKey title couponType validFrom validUntil discountPercent di
       couponType
       validFrom
       validUntil
-      Nothing
+      imageKey
       discountPercent
       discountMinimumPrice
       discountOtherConditions
@@ -619,6 +620,7 @@ dbUpdateCoupon
   -> CouponType
   -> Maybe Day
   -> Maybe Day
+  -> Maybe (Key Image)
   -> Maybe Percent
   -> Maybe Price
   -> Maybe Text
@@ -633,13 +635,14 @@ dbUpdateCoupon
   -> Maybe Text
   -> Maybe Text
   -> m ()
-dbUpdateCoupon couponKey storeKey title couponType validFrom validUntil discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
+dbUpdateCoupon couponKey storeKey title couponType validFrom validUntil imageKey discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
   dbUpdateWithTime
     [CouponId ==. couponKey, CouponStoreId ==. storeKey]
     [ CouponTitle =. title
     , CouponCouponType =. couponType
     , CouponValidFrom =. validFrom
     , CouponValidUntil =. validUntil
+    , CouponImage =. imageKey
     , CouponDiscountPercent =. discountPercent
     , CouponDiscountMinimumPrice =. discountMinimumPrice
     , CouponDiscountOtherConditions =. discountOtherConditions

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -9,18 +9,19 @@ import Control.Monad.Random (MonadRandom(..))
 import Control.Monad.Time (MonadTime(..))
 import Database.Persist.Sql
        (Entity(..), Filter, PersistRecordBackend, PersistStoreRead,
-        SelectOpt, SqlBackend, Update, (==.), (=.), (>=.), (<=.), (||.),
-        get, insert, insertEntity, insertUnique, repsert, selectFirst,
-        selectList, update, updateGet, updateWhere)
+        SelectOpt, SqlBackend, Update, (==.), (=.), (>=.), (<=.), (<-.),
+        (||.), get, insert, insertEntity, insertUnique, repsert,
+        selectFirst, selectList, update, updateGet, updateWhere)
 
 import Kucipong.Config (Config)
 import Kucipong.Db
        (Admin(..), AdminLoginToken(..), BusinessCategory(..),
         BusinessCategoryDetail(..), Coupon(..), CouponType(..),
         CreatedTime(..), DeletedTime(..), EntityField(..),
-        EntityDateFields(..), Key(..), LoginTokenExpirationTime(..),
-        Percent(..), Price(..), Store(..), StoreLoginToken(..),
-        UpdatedTime(..), emailToAdminKey, runDb, runDbCurrTime)
+        EntityDateFields(..), Image(..), ImageName(..), Key(..),
+        LoginTokenExpirationTime(..), Percent(..), Price(..), Store(..),
+        StoreLoginToken(..), UpdatedTime(..), emailToAdminKey, runDb,
+        runDbCurrTime)
 import Kucipong.LoginToken (LoginToken, createRandomLoginToken)
 import Kucipong.Monad.Db.Class
        (CouponDeleteResult(..), MonadKucipongDb(..),
@@ -439,6 +440,17 @@ dbFindAdmin = dbFindByKeyNotDeleted . emailToAdminKey
 -- Store --
 -----------
 
+dbFindImageWithStoreKey
+  :: MonadKucipongDb m
+  => Key Store -> Key Image -> m (Maybe (Entity Image))
+dbFindImageWithStoreKey storeKey imageKey =
+  dbSelectFirstNotDeleted [ImageStoreId ==. storeKey, ImageId ==. imageKey] []
+
+dbFindImage
+  :: MonadKucipongDb m
+  => Key Image -> m (Maybe (Entity Image))
+dbFindImage = dbFindByKeyNotDeleted
+
 dbFindStoreByStoreKey
   :: MonadKucipongDb m
   => Key Store -> m (Maybe (Entity Store))
@@ -455,12 +467,27 @@ dbFindStoreLoginToken
 dbFindStoreLoginToken loginToken =
   dbSelectFirstNotDeleted [StoreLoginTokenLoginToken ==. loginToken] []
 
+dbInsertImage
+  :: MonadKucipongDb m
+  => Key Store
+  -> ImageName
+  -> m (Entity Image)
+dbInsertImage storeKey imageName =
+  dbInsertWithTime $ \createdTime updatedTime deletedTime ->
+    Image
+      createdTime
+      updatedTime
+      deletedTime
+      storeKey
+      imageName
+
 dbUpdateStore
   :: MonadKucipongDb m
   => Key Store
   -> Maybe Text
   -> Maybe BusinessCategory
   -> [BusinessCategoryDetail]
+  -> Maybe (Key Image)
   -> Maybe Text
   -> Maybe Text
   -> Maybe Text
@@ -468,12 +495,13 @@ dbUpdateStore
   -> Maybe Text
   -> Maybe Text
   -> m ()
-dbUpdateStore storeKey name businessCategory businessCategoryDetails salesPoint address phoneNumber businessHours regularHoliday url =
+dbUpdateStore storeKey name businessCategory businessCategoryDetails imageKey salesPoint address phoneNumber businessHours regularHoliday url =
   dbUpdateWithTime
     [StoreId ==. storeKey]
     [ StoreName =. name
     , StoreBusinessCategory =. businessCategory
     , StoreBusinessCategoryDetails =. businessCategoryDetails
+    , StoreImage =. imageKey
     , StoreSalesPoint =. salesPoint
     , StoreAddress =. address
     , StorePhoneNumber =. phoneNumber
@@ -481,6 +509,14 @@ dbUpdateStore storeKey name businessCategory businessCategoryDetails salesPoint 
     , StoreRegularHoliday =. regularHoliday
     , StoreUrl =. url
     ]
+
+dbUpdateStoreImage
+  :: MonadKucipongDb m
+  => Key Store
+  -> Maybe (Key Image)
+  -> m ()
+dbUpdateStoreImage storeKey maybeImageKey =
+  dbUpdateWithTime [StoreId ==. storeKey] [StoreImage =. maybeImageKey]
 
 ------------
 -- Coupon --
@@ -547,6 +583,34 @@ dbFindCouponsByStoreKey
 dbFindCouponsByStoreKey storeKey =
   dbSelectListNotDeleted [CouponStoreId ==. storeKey] []
 
+dbFindImagesForCoupons
+  :: MonadKucipongDb m
+  => [Entity Coupon] -> m [(Entity Coupon, Maybe (Entity Image))]
+dbFindImagesForCoupons couponEntities = do
+  let couponImageKeys =
+        catMaybes $ fmap (couponImage . entityVal) couponEntities
+  imageEntities <- dbSelectListNotDeleted [ImageId <-. couponImageKeys] []
+  pure $ matchCouponsWithImages imageEntities couponEntities
+  where
+    matchCouponsWithImages
+      :: [Entity Image]
+      -> [Entity Coupon]
+      -> [(Entity Coupon, Maybe (Entity Image))]
+    matchCouponsWithImages images = fmap $ findImageForCouponEntity images
+
+    findImageForCouponEntity
+      :: [Entity Image]
+      -> Entity Coupon
+      -> (Entity Coupon, Maybe (Entity Image))
+    findImageForCouponEntity images couponEntity =
+      let maybeImageKey = couponImage $ entityVal couponEntity
+          maybeImageEntity = maybeImageKey >>= findImageWithKey images
+      in (couponEntity, maybeImageEntity)
+
+    findImageWithKey :: [Entity Image] -> Key Image -> Maybe (Entity Image)
+    findImageWithKey images imageKey =
+      find (\imageEntity -> entityKey imageEntity == imageKey) images
+
 dbUpdateCoupon
   :: MonadKucipongDb m
   => Key Coupon
@@ -590,6 +654,17 @@ dbUpdateCoupon couponKey storeKey title couponType validFrom validUntil discount
     , CouponOtherContent =. otherContent
     , CouponOtherConditions =. otherConditions
     ]
+
+dbUpdateCouponImage
+  :: MonadKucipongDb m
+  => Key Coupon
+  -> Key Store
+  -> Maybe (Key Image)
+  -> m ()
+dbUpdateCouponImage couponKey storeKey maybeImageKey =
+  dbUpdateWithTime
+    [CouponId ==. couponKey, CouponStoreId ==. storeKey]
+    [CouponImage =. maybeImageKey]
 
 --------------
 -- Consumer --

--- a/src/Kucipong/Orphans.hs
+++ b/src/Kucipong/Orphans.hs
@@ -47,5 +47,3 @@ instance ToMarkup Natural where
   toMarkup = string . show
 
 deriving instance Data UploadedFile
-deriving instance Show UploadedFile
-

--- a/src/Kucipong/Spock.hs
+++ b/src/Kucipong/Spock.hs
@@ -1,6 +1,7 @@
 
 module Kucipong.Spock
-    ( module Kucipong.Spock.ReqParam
+    ( module Kucipong.Spock.Json
+    , module Kucipong.Spock.ReqParam
     , setAdminCookie
     , setStoreCookie
     , getAdminCookie
@@ -24,6 +25,7 @@ import Kucipong.Monad (MonadKucipongCookie(..))
 import Kucipong.Session
        (Session(AdminSession, StoreSessionRaw),
         SessionType(SessionTypeAdmin, SessionTypeStore))
+import Kucipong.Spock.Json
 import Kucipong.Spock.ReqParam
 
 setAdminCookie

--- a/src/Kucipong/Spock/Json.hs
+++ b/src/Kucipong/Spock/Json.hs
@@ -10,13 +10,21 @@ module Kucipong.Spock.Json where
 import Kucipong.Prelude
 
 import Data.Aeson (ToJSON)
+import Network.HTTP.Types.Status (Status)
 import Web.Envelope (Success(Success), toErr)
-import Web.Spock.Core (ActionCtxT, json)
+import Web.Spock.Core (ActionCtxT, json, setStatus)
 
 jsonError
   :: (MonadIO m, ToJSON a)
   => a -> Text -> ActionCtxT ctx m b
 jsonError a = json . toErr a
+
+jsonErrorStatus
+  :: (MonadIO m, ToJSON a)
+  => Status -> a -> Text -> ActionCtxT ctx m b
+jsonErrorStatus status a msg = do
+  setStatus status
+  jsonError a msg
 
 jsonSuccess
   :: (MonadIO m, ToJSON a)

--- a/src/Kucipong/Spock/Json.hs
+++ b/src/Kucipong/Spock/Json.hs
@@ -1,0 +1,24 @@
+{-|
+Module      : Kucipong.Spock.Json
+Description : Helper functions for json.
+Stability   : experimental
+Portability : POSIX
+-}
+
+module Kucipong.Spock.Json where
+
+import Kucipong.Prelude
+
+import Data.Aeson (ToJSON)
+import Web.Envelope (Success(Success), toErr)
+import Web.Spock.Core (ActionCtxT, json)
+
+jsonError
+  :: (MonadIO m, ToJSON a)
+  => a -> Text -> ActionCtxT ctx m b
+jsonError a = json . toErr a
+
+jsonSuccess
+  :: (MonadIO m, ToJSON a)
+  => a -> ActionCtxT ctx m b
+jsonSuccess = json . Success

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,8 @@ extra-deps:
     - emailaddress-0.2.0.0
     # This should be available in lts-8.
     - pretty-simple-1.1.0.3
+    # This should be available in lts-8.
+    - envelope-0.2.1.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,6 +22,12 @@ extra-deps:
     - pretty-simple-1.1.0.3
     # This should be available in lts-8.
     - envelope-0.2.1.0
+    # This should be available in lts-8.
+    - Spock-0.12.0.0
+    - Spock-core-0.12.0.0
+    - superbuffer-0.3.1.0
+    - hvect-0.4.0.0
+
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This PR adds an `Image` table to hold images uploaded to Kucipong.  It changes the `Store` and `Coupon` tables to reference this `Image` table.

Since this PR changes tables, you'll have to run the following sql commands before you run the API:

```sql
drop table "coupon" cascade ;
drop table "store_login_token" cascade ;
drop table "store" cascade ;
```

Three new APIs have been added.

1.  POST Images.  This API is for uploading new image files.  It accepts `multipart/form-data`.  This creates a new entry in the `Image` table.  

    Assuming you have an image in the current directory called `goat-cafe.jpg`, you can upload it with `curl` using the following command:

    ```sh
    $ curl --verbose --request POST \
        --cookie 'storeEmail=3zydRKER%2Bho4wzyG2hxfYFcKQ4ga8T19FIwqRJYd84LG%2Bo9Tlt8FxplOV%2BuDP5WRPw%3D%3D' \
        -F 'image=@goat-cafe.jpg' \
        'http://localhost:8101/store/image'
    {"data":3}
    ```

    The return value is a [`Envelope`](https://hackage.haskell.org/package/envelope-0.2.1.0/docs/Web-Envelope.html) with the `Image` key.

    There is currently no way to delete images that have been uploaded.

2.  Set an `Image` for a `Store`.  This sets a `Store`'s `image` column to an `Image` key that has been uploaded in (1).

    This is a JSON API and can be accessed with `curl` like the following:

    ```sh
    $ curl --verbose --request POST --header 'Accept: application/json' \
        --cookie 'storeEmail=3zydRKER%2Bho4wzyG2hxfYFcKQ4ga8T19FIwqRJYd84LG%2Bo9Tlt8FxplOV%2BuDP5WRPw%3D%3D' \
        --data '{"imageKey": 3}' \
        'http://localhost:8101/store/set/image'
    ```

    If the image doesn't exist or the `Image`'s owner is not the current user, an error will be returned.

3.  Set an `Image` for a `Coupon`.  This is just like (2), but for a `Coupon` instead of a `Store` 

    ```sh
    $ curl --verbose --request POST --header 'Accept: application/json' \
        --cookie 'storeEmail=3zydRKER%2Bho4wzyG2hxfYFcKQ4ga8T19FIwqRJYd84LG%2Bo9Tlt8FxplOV%2BuDP5WRPw%3D%3D' \
        --data '{"imageKey": 2}' \
        'http://localhost:8101/store/coupon/1/set/image'
    ```

Fixes #161.