### PR TITLE
store GET handler for the end user

### DIFF
--- a/frontend/src/pug/store_id.pug
+++ b/frontend/src/pug/store_id.pug
@@ -5,17 +5,28 @@ include common/_layout
     .store
       header.storeHeader
         .annotatedImageGroup
-          img.annotatedImageGroup-image(src=require("../img/dummy.jpg") alt="七輪焼き肉・安安")
+          | %{ case format ImageUrl imageUrl }
+          | %{ of Just url }
+          img.annotatedImageGroup-image(
+            src="\#{url}"
+            alt="\#{format StoreName store}"
+          )
           span.annotatedImageGroup-annotation 画像は一例です
+          | %{ of _ }
+          div
+            | 画像が設定されていません
+          | %{ endcase }
         .highlightedBlock
           h2.highlightedBlock.storeHeader-title
-            | 七輪焼肉・安安
+            | \#{format StoreName store}
       .storeBody
         .storeBody_description
-          p 七輪焼き肉・安安は、美味しい焼肉を...
-          p ...
+          p \#{format StoreSalesPoint store}
         .storeBody_viewCoupon
-          a.btn.defaultBtn(href="/store/52/coupon") クーポンを見る
+          a.btn.defaultBtn(
+            href="\#{renderRoute consumerStoreVarCouponR (entityKey storeEntity)}"
+          )
+            | クーポンを見る
         .storeBody_info
           .storeBody_info_titleArea
             .storeBody_info_titleArea-text
@@ -25,21 +36,24 @@ include common/_layout
               .storeBody_info_body_row-header
                 | 住所
               .storeBody_info_body_row-body
-                | 渋谷区桜丘町2-12 渋谷亀八ビル4F
+                | \#{format StoreAddress store}
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 電話番号
               .storeBody_info_body_row-body
-                | 03-3464-0722
+                | \#{format StorePhoneNumber store}
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 営業時間
               .storeBody_info_body_row-body
-                | 月〜木 17:00〜翌4:30\n金土日祝・祝前 16:00〜翌4:30
+                | %{ forall businessHour <- format StoreBusinessHour store }
+                p
+                  | \#{businessHour}
+                | %{ endforall }
             .storeBody_info_body_row
               .storeBody_info_body_row-header
                 | 定休日
               .storeBody_info_body_row-body
-                | 元旦のみ
+                | \#{format StoreRegularHoliday store}
             .storeBody_info_body_btnRow
-              a.btn.outerBtn(href="http://www.fuji-tatsu.co.jp/") オフィシャルサイト
+              a.btn.outerBtn(href="\#{format StoreUrl store}") オフィシャルサイト

--- a/src/Kucipong/Handler/Consumer.hs
+++ b/src/Kucipong/Handler/Consumer.hs
@@ -12,20 +12,22 @@ import Database.Persist.Sql (Entity(..))
 import Web.Spock (ActionCtxT, renderRoute)
 import Web.Spock.Core (SpockCtxT, get)
 
-import Kucipong.Db (Coupon(..), CouponType(..), Key(..))
+import Kucipong.Db
+       (Coupon(..), CouponType(..), Image(..), Key(..), Store(..))
 import Kucipong.Handler.Consumer.TemplatePath
 import Kucipong.Handler.Consumer.Types (ConsumerError(..))
 import Kucipong.Handler.Error (resp404)
 import Kucipong.Handler.Route
-       (consumerCouponVarR, consumerStoreVarR)
+       (consumerCouponVarR, consumerStoreVarR, consumerStoreVarCouponR)
 import Kucipong.Handler.Store.Types
-       (CouponViewText(..), CouponViewTexts(..), CouponViewCouponType(..),
-        StoreError(..), StoreViewText(..))
-import Kucipong.Handler.Store.Util (awsUrlFromMaybeImageKey)
+       (CouponViewCouponType(..),
+        CouponViewText(..), CouponViewTexts(..),
+        CouponViewCouponType(..), StoreError(..),
+        StoreViewText(..), StoreViewTexts(..))
 import Kucipong.I18n (label)
 import Kucipong.Monad
-       (MonadKucipongAws(..), MonadKucipongDb(..), dbFindPublicCouponById,
-        dbFindStoreByStoreKey)
+       (MonadKucipongAws(..), MonadKucipongDb(..), awsImageS3Url,
+        dbFindImage, dbFindPublicCouponById, dbFindStoreByStoreKey)
 import Kucipong.RenderTemplate (renderTemplateFromEnv)
 import Kucipong.View.Instance (ImageUrl(..))
 
@@ -40,8 +42,7 @@ couponGet couponKey = do
   maybeStoreEntity <- dbFindStoreByStoreKey . couponStoreId . entityVal $ coupon
   store <-
     fromMaybeM (resp404 [label def StoreErrorNoStore]) maybeStoreEntity
-  let maybeImageKey = couponImage . entityVal =<< maybeCouponEntity
-  imageUrl <- awsUrlFromMaybeImageKey maybeImageKey
+  imageUrl <- imageUrlFromImageKey . couponImage $ entityVal coupon
   let
     aboutStore =
       maybe mempty
@@ -54,8 +55,39 @@ couponGet couponKey = do
       let errors = [errMsg]
       $(renderTemplateFromEnv templateCategory)
 
+storeGet
+  :: forall ctx m.
+     (MonadIO m, MonadKucipongAws m, MonadKucipongDb m)
+  => Key Store -> ActionCtxT ctx m ()
+storeGet storeKey = do
+  maybeStoreEntity <- dbFindStoreByStoreKey storeKey
+  storeEntity <-
+    fromMaybeM
+      (handleErr $ label def ConsumerErrorCouldNotFindStore)
+      maybeStoreEntity
+  imageUrl <- imageUrlFromImageKey . storeImage $ entityVal storeEntity
+  store <-
+    fromMaybeM (resp404 [label def StoreErrorNoStore]) maybeStoreEntity
+  $(renderTemplateFromEnv templateStoreId)
+  where
+    handleErr :: Text -> ActionCtxT ctx m a
+    handleErr errMsg = do
+      let errors = [errMsg]
+      $(renderTemplateFromEnv templateCategory)
+
+imageUrlFromImageKey
+  :: (MonadKucipongAws m, MonadKucipongDb m)
+  => Maybe (Key Image) -> m (Maybe Text)
+imageUrlFromImageKey maybeImageKey = do
+  maybeImageEntity <- join <$> traverse dbFindImage maybeImageKey
+  let maybeImageName = imageS3Name . entityVal <$> maybeImageEntity
+  traverse awsImageS3Url maybeImageName
+
 consumerComponent
   :: forall m.
      (MonadIO m, MonadKucipongAws m, MonadKucipongDb m)
   => SpockCtxT () m ()
-consumerComponent = get consumerCouponVarR couponGet
+consumerComponent = do
+  get consumerCouponVarR couponGet
+  get consumerStoreVarR storeGet
+  get consumerStoreVarCouponR undefined

--- a/src/Kucipong/Handler/Consumer/TemplatePath.hs
+++ b/src/Kucipong/Handler/Consumer/TemplatePath.hs
@@ -15,3 +15,7 @@ templateCouponId = templateRoot </> "coupon_id.html"
 
 templateCategory :: FilePath
 templateCategory = templateRoot </> "category.html"
+
+templateStoreId :: FilePath
+templateStoreId = templateRoot </> "store_id.html"
+

--- a/src/Kucipong/Handler/Consumer/Types.hs
+++ b/src/Kucipong/Handler/Consumer/Types.hs
@@ -7,6 +7,7 @@ import Kucipong.Prelude
 
 data ConsumerError
   = ConsumerErrorCouldNotFindCoupon
+  | ConsumerErrorCouldNotFindStore
   deriving (Show, Eq, Ord, Read, Enum, Bounded)
 
 -- data ConsumerMsg

--- a/src/Kucipong/Handler/Route.hs
+++ b/src/Kucipong/Handler/Route.hs
@@ -113,3 +113,6 @@ consumerCouponVarR = consumerR <//> couponR <//> var
 
 consumerStoreVarR :: Path '[Key Store] 'Open
 consumerStoreVarR = consumerR <//> storeR <//> var
+
+consumerStoreVarCouponR :: Path '[Key Store] 'Open
+consumerStoreVarCouponR = consumerR <//> storeR <//> var <//> couponR

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -15,9 +15,6 @@ module Kucipong.Handler.Store.Types
 import Kucipong.Prelude
 
 import Data.Aeson.TH (defaultOptions, deriveJSON)
-import Database.Persist (Entity(..))
-
-import Kucipong.Db (Coupon(..), Store(..))
 
 -- For I18n.
 data StoreError

--- a/src/Kucipong/I18n/Instance.hs
+++ b/src/Kucipong/I18n/Instance.hs
@@ -48,6 +48,8 @@ instance I18n AdminMsg where
 instance I18n ConsumerError where
   label EnUS ConsumerErrorCouldNotFindCoupon =
     "Could not find coupon. The coupon you requested is not available or URL is invalid."
+  label EnUS ConsumerErrorCouldNotFindStore =
+    "Could not find store. The store you requested is not available or URL is invalid."
 
 instance I18n StoreDeleteResult where
   label EnUS StoreDeleteSuccess = "Successfully deleted store."


### PR DESCRIPTION
This adds a store GET handler for the end user.

It can be accessed with a URL like the following:

http://localhost:8101/store/1

The `frontend/src/pug/store_id.pug` template might need some further updates.

This is for #14.