### PR TITLE
Get rid of imageKey field from CouponEditForm/StoreEditForm.

### DIFF
--- a/src/Kucipong/Form.hs
+++ b/src/Kucipong/Form.hs
@@ -81,7 +81,6 @@ data StoreEditForm = StoreEditForm
   { name :: !(Maybe Text)
   , businessCategory :: !(Maybe BusinessCategory)
   , businessCategoryDetails :: ![BusinessCategoryDetail]
-  , imageKey :: !(Maybe (Key Image))
   , salesPoint :: !(Maybe Text)
   , address :: !(Maybe Text)
   , phoneNumber :: !(Maybe Text)
@@ -107,7 +106,6 @@ data StoreNewCouponForm = StoreNewCouponForm
   , couponType :: CouponType
   , validFrom :: !(MaybeEmpty Day)
   , validUntil :: !(MaybeEmpty Day)
-  , imageKey :: !(MaybeEmpty (Key Image))
   , discountPercent :: !(MaybeEmpty Percent)
   , discountMinimumPrice :: !(MaybeEmpty Price)
   , discountOtherConditions :: !(MaybeEmpty Text)

--- a/src/Kucipong/Handler/Store.hs
+++ b/src/Kucipong/Handler/Store.hs
@@ -231,7 +231,6 @@ storeEditPost = do
   StoreEditForm { name
                 , businessCategory
                 , businessCategoryDetails
-                , imageKey
                 , salesPoint
                 , address
                 , phoneNumber
@@ -241,15 +240,12 @@ storeEditPost = do
                 } <- getReqParamErr handleErr
   let businessCategoryDetails' =
         filterBusinessCategoryDetails businessCategory businessCategoryDetails
-  guardMaybeImageKeyOwnedByStore storeKey imageKey $
-    handleErr (label def StoreErrorImageOwnedByStore)
   void $
     dbUpdateStore
       storeKey
       name
       businessCategory
       (nub businessCategoryDetails')
-      imageKey
       salesPoint
       address
       phoneNumber

--- a/src/Kucipong/Handler/Store/Coupon.hs
+++ b/src/Kucipong/Handler/Store/Coupon.hs
@@ -111,7 +111,6 @@ couponEditPost couponKey = do
       couponType
       (view _Wrapped validFrom)
       (view _Wrapped validUntil)
-      (view _Wrapped imageKey)
       (view _Wrapped discountPercent)
       (view _Wrapped discountMinimumPrice)
       (view _Wrapped discountOtherConditions)
@@ -174,7 +173,6 @@ couponPost = do
       couponType
       (view _Wrapped validFrom)
       (view _Wrapped validUntil)
-      (view _Wrapped imageKey)
       (view _Wrapped discountPercent)
       (view _Wrapped discountMinimumPrice)
       (view _Wrapped discountOtherConditions)

--- a/src/Kucipong/Handler/Store/Types.hs
+++ b/src/Kucipong/Handler/Store/Types.hs
@@ -15,9 +15,6 @@ module Kucipong.Handler.Store.Types
 import Kucipong.Prelude
 
 import Data.Aeson.TH (defaultOptions, deriveJSON)
-import Database.Persist (Entity(..))
-
-import Kucipong.Db (Coupon(..), Store(..))
 
 -- For I18n.
 data StoreError

--- a/src/Kucipong/Monad/Db/Instance.hs
+++ b/src/Kucipong/Monad/Db/Instance.hs
@@ -487,7 +487,6 @@ dbUpdateStore
   -> Maybe Text
   -> Maybe BusinessCategory
   -> [BusinessCategoryDetail]
-  -> Maybe (Key Image)
   -> Maybe Text
   -> Maybe Text
   -> Maybe Text
@@ -495,13 +494,12 @@ dbUpdateStore
   -> Maybe Text
   -> Maybe Text
   -> m ()
-dbUpdateStore storeKey name businessCategory businessCategoryDetails imageKey salesPoint address phoneNumber businessHours regularHoliday url =
+dbUpdateStore storeKey name businessCategory businessCategoryDetails salesPoint address phoneNumber businessHours regularHoliday url =
   dbUpdateWithTime
     [StoreId ==. storeKey]
     [ StoreName =. name
     , StoreBusinessCategory =. businessCategory
     , StoreBusinessCategoryDetails =. businessCategoryDetails
-    , StoreImage =. imageKey
     , StoreSalesPoint =. salesPoint
     , StoreAddress =. address
     , StorePhoneNumber =. phoneNumber
@@ -529,7 +527,6 @@ dbInsertCoupon
   -> CouponType
   -> Maybe Day
   -> Maybe Day
-  -> Maybe (Key Image)
   -> Maybe Percent
   -> Maybe Price
   -> Maybe Text
@@ -544,7 +541,7 @@ dbInsertCoupon
   -> Maybe Text
   -> Maybe Text
   -> m (Entity Coupon)
-dbInsertCoupon storeKey title couponType validFrom validUntil imageKey discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
+dbInsertCoupon storeKey title couponType validFrom validUntil discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
   dbInsertWithTime $ \createdTime updatedTime deletedTime ->
     Coupon
       storeKey
@@ -555,7 +552,7 @@ dbInsertCoupon storeKey title couponType validFrom validUntil imageKey discountP
       couponType
       validFrom
       validUntil
-      imageKey
+      Nothing
       discountPercent
       discountMinimumPrice
       discountOtherConditions
@@ -620,7 +617,6 @@ dbUpdateCoupon
   -> CouponType
   -> Maybe Day
   -> Maybe Day
-  -> Maybe (Key Image)
   -> Maybe Percent
   -> Maybe Price
   -> Maybe Text
@@ -635,14 +631,13 @@ dbUpdateCoupon
   -> Maybe Text
   -> Maybe Text
   -> m ()
-dbUpdateCoupon couponKey storeKey title couponType validFrom validUntil imageKey discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
+dbUpdateCoupon couponKey storeKey title couponType validFrom validUntil discountPercent discountMinimumPrice discountOtherConditions giftContent giftReferencePrice giftMinimumPrice giftOtherConditions setContent setPrice setReferencePrice setOtherConditions otherContent otherConditions =
   dbUpdateWithTime
     [CouponId ==. couponKey, CouponStoreId ==. storeKey]
     [ CouponTitle =. title
     , CouponCouponType =. couponType
     , CouponValidFrom =. validFrom
     , CouponValidUntil =. validUntil
-    , CouponImage =. imageKey
     , CouponDiscountPercent =. discountPercent
     , CouponDiscountMinimumPrice =. discountMinimumPrice
     , CouponDiscountOtherConditions =. discountOtherConditions


### PR DESCRIPTION
This PR resolves #177.
This get rid of `imageKey` from CouponEditForm/StoreEditForm because we should not update images with `CouponEditForm`/`StoreEditForm` now.